### PR TITLE
III/VC cross-compile fixes

### DIFF
--- a/DDraw/DDraw.def
+++ b/DDraw/DDraw.def
@@ -1,3 +1,3 @@
 LIBRARY DDRAW
 EXPORTS
-	DirectDrawCreateEx=_DirectDrawCreateEx@16 @10
+	DirectDrawCreateEx = DirectDrawCreateEx@16

--- a/DDraw/DDraw.vcxproj
+++ b/DDraw/DDraw.vcxproj
@@ -83,7 +83,6 @@
       <AdditionalOptions>/Zc:threadSafeInit- /Zc:strictStrings %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <ModuleDefinitionFile>ddraw.def</ModuleDefinitionFile>
       <SubSystem>Windows</SubSystem>
       <DelayLoadDLLs>shell32.dll;shlwapi.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <LargeAddressAware>true</LargeAddressAware>
@@ -113,7 +112,6 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <ModuleDefinitionFile>ddraw.def</ModuleDefinitionFile>
       <SubSystem>Windows</SubSystem>
       <DelayLoadDLLs>shell32.dll;shlwapi.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <LargeAddressAware>true</LargeAddressAware>
@@ -143,7 +141,6 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <ModuleDefinitionFile>ddraw.def</ModuleDefinitionFile>
       <SubSystem>Windows</SubSystem>
       <DelayLoadDLLs>shell32.dll;shlwapi.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <LargeAddressAware>true</LargeAddressAware>

--- a/DDraw/dllmain.cpp
+++ b/DDraw/dllmain.cpp
@@ -4,8 +4,8 @@
 
 #include <windows.h>
 #include <stdio.h>
-#include <Shlwapi.h>
-#include <ShlObj.h>
+#include <shlwapi.h>
+#include <shlobj.h>
 #include "Utils/MemoryMgr.h"
 #include "Utils/Patterns.h"
 #include "Utils/ScopedUnprotect.hpp"

--- a/DDraw/dllmain.cpp
+++ b/DDraw/dllmain.cpp
@@ -200,7 +200,7 @@ static bool PatchIAT_ByPointers()
 	using namespace Memory::VP;
 
 	pOrgSystemParametersInfoA = SystemParametersInfoA;
-	memcpy( orgCode, pOrgSystemParametersInfoA, sizeof(orgCode) );
+	memcpy( orgCode, reinterpret_cast<void*>(pOrgSystemParametersInfoA), sizeof(orgCode) );
 	InjectHook( pOrgSystemParametersInfoA, SystemParametersInfoA_OverwritingHook, HookType::Jump );
 	return true;
 }

--- a/DDraw/dllmain.cpp
+++ b/DDraw/dllmain.cpp
@@ -14,6 +14,7 @@
 #include "Desktop.h"
 
 #pragma comment(lib, "shlwapi.lib")
+#pragma comment(linker, "/EXPORT:DirectDrawCreateEx=_DirectDrawCreateEx@16")
 
 extern "C" HRESULT WINAPI DirectDrawCreateEx(GUID FAR *lpGUID, LPVOID *lplpDD, REFIID iid, IUnknown FAR *pUnkOuter)
 {

--- a/SilentPatch/Common.cpp
+++ b/SilentPatch/Common.cpp
@@ -34,7 +34,7 @@ namespace HandlingNameLoadFix
 // ============= Corona lines rendering fix =============
 namespace CoronaLinesFix
 {
-	static decltype(RwIm2DRenderLine)* orgRwIm2DRenderLine;
+	static RwIm2DRenderLineFunction orgRwIm2DRenderLine;
 	static RwBool RenderLine_SetRecipZ( RwIm2DVertex *vertices, RwInt32 numVertices, RwInt32 vert1, RwInt32 vert2 )
 	{
 		const RwReal nearScreenZ = RwIm2DGetNearScreenZ();

--- a/SilentPatch/Common.h
+++ b/SilentPatch/Common.h
@@ -2,6 +2,13 @@
 
 #include <cstdint>
 
+// Workaround for old MSVC inline function bugs
+#if defined(_MSC_VER) && _MSC_VER < 1930
+#define STATIC_INLINE static
+#else
+#define STATIC_INLINE static inline
+#endif
+
 namespace ExtraCompSpecularity
 {
 	void ReadExtraCompSpecularityExceptions(const wchar_t* pPath);

--- a/SilentPatch/Common_ddraw.cpp
+++ b/SilentPatch/Common_ddraw.cpp
@@ -1,12 +1,12 @@
-#include "Common_ddraw.h"
-
-#include "Desktop.h"
-
 #define WIN32_LEAN_AND_MEAN
 
 #define WINVER 0x0501
 #define _WIN32_WINNT 0x0501
 #define NOMINMAX
+
+#include "Common_ddraw.h"
+
+#include "Desktop.h"
 
 #include <windows.h>
 

--- a/SilentPatch/Common_ddraw.cpp
+++ b/SilentPatch/Common_ddraw.cpp
@@ -10,8 +10,8 @@
 
 #include <windows.h>
 
-#include <Shlwapi.h>
-#include <ShlObj.h>
+#include <shlwapi.h>
+#include <shlobj.h>
 #include "Utils/MemoryMgr.h"
 #include "Utils/Patterns.h"
 

--- a/SilentPatch/Common_ddraw.cpp
+++ b/SilentPatch/Common_ddraw.cpp
@@ -17,8 +17,6 @@
 
 #pragma comment(lib, "shlwapi.lib")
 
-extern char** ppUserFilesDir;
-
 // ============= Fake the VRAM poll =============
 namespace FakeVRAMPoll
 {

--- a/SilentPatch/Common_ddraw.h
+++ b/SilentPatch/Common_ddraw.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+extern char** ppUserFilesDir;
+
 namespace Common
 {
 	namespace Patches

--- a/SilentPatch/Desktop.cpp
+++ b/SilentPatch/Desktop.cpp
@@ -1,10 +1,10 @@
-#include "Desktop.h"
-
 #define WIN32_LEAN_AND_MEAN
 
 #define WINVER 0x0501
 #define _WIN32_WINNT 0x0501
 #define NOMINMAX
+
+#include "Desktop.h"
 
 #include <windows.h>
 

--- a/SilentPatch/FriendlyMonitorNames.cpp
+++ b/SilentPatch/FriendlyMonitorNames.cpp
@@ -1,11 +1,11 @@
-#include "FriendlyMonitorNames.h"
-
 // This API is Win7 only, so make sure we use dynamic imports
 #define WIN32_LEAN_AND_MEAN
 
 #define NOMINMAX
 #define WINVER 0x0602
 #define _WIN32_WINNT 0x0602
+
+#include "FriendlyMonitorNames.h"
 
 #include <windows.h>
 

--- a/SilentPatch/Maths.h
+++ b/SilentPatch/Maths.h
@@ -6,6 +6,15 @@
 
 #include <rwcore.h>
 
+// FIXME: Common.h might be a better place for this (but SA doesn't include it)
+#ifdef _MSC_VER
+#define NOBUFFERCHECKS __declspec(safebuffers)
+#elif defined(__GNUC__) && !defined(__clang__)
+#define NOBUFFERCHECKS __attribute__((optimize("-fno-stack-protector")))
+#else
+#define NOBUFFERCHECKS __attribute__((no_stack_protector))
+#endif
+
 constexpr double RAD_TO_DEG (180.0/M_PI);
 constexpr double DEG_TO_RAD (M_PI/180.0);
 

--- a/SilentPatch/ParseUtils.cpp
+++ b/SilentPatch/ParseUtils.cpp
@@ -2,7 +2,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
-#include <Windows.h>
+#include <windows.h>
 
 static std::string WcharToUTF8(std::wstring_view str)
 {

--- a/SilentPatch/ParseUtils.cpp
+++ b/SilentPatch/ParseUtils.cpp
@@ -1,7 +1,8 @@
-#include "ParseUtils.hpp"
-
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
+
+#include "ParseUtils.hpp"
+
 #include <windows.h>
 
 static std::string WcharToUTF8(std::wstring_view str)

--- a/SilentPatch/RWGTA.cpp
+++ b/SilentPatch/RWGTA.cpp
@@ -1,8 +1,6 @@
 #include "Utils/MemoryMgr.h"
 #include "Utils/Patterns.h"
 
-#define RwEngineInstance (*rwengine)
-
 #include <rwcore.h>
 #include "RWGTA.h"
 

--- a/SilentPatch/RWGTA.cpp
+++ b/SilentPatch/RWGTA.cpp
@@ -78,19 +78,19 @@ bool RWGTA::Patches::TryLocateRwD3D8() try
 	auto pfnRwD3D8SetRenderState = [] {
 		try {
 			// Everything except for III Steam
-			return static_cast<decltype(RwD3D8SetRenderState)*>(get_pattern("39 0C C5 ? ? ? ? 74 31", -8));
+			return reinterpret_cast<decltype(RwD3D8SetRenderState)*>(get_pattern("39 0C C5 ? ? ? ? 74 31", -8));
 		} catch (const hook::txn_exception&) {
 			// III Steam
-			return static_cast<decltype(RwD3D8SetRenderState)*>(get_pattern("8B 0C C5 ? ? ? ? 3B CA", -8));
+			return reinterpret_cast<decltype(RwD3D8SetRenderState)*>(get_pattern("8B 0C C5 ? ? ? ? 3B CA", -8));
 		}
 	}();
 	auto pfnRwD3D8GetRenderState = [] {
 		try {
 			// Everything except for III Steam
-			return static_cast<decltype(RwD3D8GetRenderState)*>(get_pattern("8B 0C C5 ? ? ? ? 89 0A C3", -8));
+			return reinterpret_cast<decltype(RwD3D8GetRenderState)*>(get_pattern("8B 0C C5 ? ? ? ? 89 0A C3", -8));
 		} catch (const hook::txn_exception&) {
 			// III Steam
-			return static_cast<decltype(RwD3D8GetRenderState)*>(get_pattern("8B 04 C5 ? ? ? ? 89 02 C3", -8));
+			return reinterpret_cast<decltype(RwD3D8GetRenderState)*>(get_pattern("8B 04 C5 ? ? ? ? 89 02 C3", -8));
 		}
 	}();
 

--- a/SilentPatch/RWGTA.cpp
+++ b/SilentPatch/RWGTA.cpp
@@ -52,6 +52,7 @@ void RwD3D8GetRenderState(RwUInt32 state, void* value)
 	fnRwD3D8GetRenderState(state, value);
 }
 
+#ifndef RwIm2DGetNearScreenZ
 RwReal RwIm2DGetNearScreenZ()
 {
 	return RWSRCGLOBAL(dOpenDevice).zBufferNear;
@@ -66,6 +67,7 @@ RwBool RwRenderStateSet(RwRenderState state, void *value)
 {
 	return RWSRCGLOBAL(dOpenDevice).fpRenderStateSet(state, value);
 }
+#endif
 
 // Unreachable stub
 RwBool RwMatrixDestroy(RwMatrix* /*mpMat*/) { assert(!"Unreachable!"); return TRUE; }

--- a/SilentPatch/RWGTA.h
+++ b/SilentPatch/RWGTA.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#define RwEngineInstance (*rwengine)
+
+extern void** rwengine;
+
 namespace RWGTA::Patches
 {
 	bool TryLocateRwD3D8();

--- a/SilentPatch/RWUtils.hpp
+++ b/SilentPatch/RWUtils.hpp
@@ -3,6 +3,10 @@
 #include <rwcore.h>
 #include <rpworld.h>
 
+#define RwEngineInstance (*rwengine)
+
+extern void** rwengine;
+
 template<RwRenderState State>
 class RwScopedRenderState
 {

--- a/SilentPatch/SVF.cpp
+++ b/SilentPatch/SVF.cpp
@@ -5,6 +5,11 @@
 #include <algorithm>
 #include <map>
 
+#ifndef _MSC_VER
+#include <cstring>
+#define _stricmp strcasecmp
+#endif
+
 namespace SVF
 {
 	static Feature GetFeatureFromName( const char* featureName )

--- a/SilentPatch/SVF.cpp
+++ b/SilentPatch/SVF.cpp
@@ -1,6 +1,5 @@
 #include "SVF.h"
 
-#include <cstdint>
 #include <cctype>
 #include <algorithm>
 #include <map>

--- a/SilentPatch/SVF.h
+++ b/SilentPatch/SVF.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <string>
 

--- a/SilentPatch/TheFLAUtils.cpp
+++ b/SilentPatch/TheFLAUtils.cpp
@@ -1,7 +1,7 @@
 #include "TheFLAUtils.h"
 
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
 #include "Utils/ModuleList.hpp"
 

--- a/SilentPatch/Timer.h
+++ b/SilentPatch/Timer.h
@@ -1,6 +1,8 @@
 #ifndef __TIMER
 #define __TIMER
 
+#include <cmath>
+
 class CTimer
 {
 public:

--- a/SilentPatchIII/ModelInfoIII.h
+++ b/SilentPatchIII/ModelInfoIII.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include "Maths.h"
 
 #include <rwcore.h>

--- a/SilentPatchIII/SilentPatchIII.cpp
+++ b/SilentPatchIII/SilentPatchIII.cpp
@@ -1262,7 +1262,7 @@ namespace SlidingTextsScalingFixes
 		static inline float** pHorShadowValue;
 
 		template<std::size_t Index>
-		static void (*orgPrintString)(float,float,const wchar_t*);
+		STATIC_INLINE void (*orgPrintString)(float,float,const wchar_t*);
 
 		template<std::size_t Index>
 		static void PrintString_Slide(float fX, float fY, const wchar_t* pText)
@@ -1282,7 +1282,7 @@ namespace SlidingTextsScalingFixes
 		}
 
 		template<std::size_t Index>
-		static void (*orgSetRightJustifyWrap)(float wrap);
+		STATIC_INLINE void (*orgSetRightJustifyWrap)(float wrap);
 
 		template<std::size_t Index>
 		static void SetRightJustifyWrap_Slide(float wrap)
@@ -1299,7 +1299,7 @@ namespace SlidingTextsScalingFixes
 		static inline bool bSlidingEnabled = false;
 
 		template<std::size_t Index>
-		static void (*orgPrintString)(float,float,const wchar_t*);
+		STATIC_INLINE void (*orgPrintString)(float,float,const wchar_t*);
 
 		template<std::size_t Index>
 		static void PrintString_Slide(float fX, float fY, const wchar_t* pText)
@@ -1400,7 +1400,7 @@ namespace FixedLineWraps
 	struct WrapInternal
 	{
 		template<std::size_t Index>
-		static void (*orgWrapFunction)(float);
+		STATIC_INLINE void (*orgWrapFunction)(float);
 
 		template<std::size_t Index>
 		static void WrapFunction_LeftAlign(float fLength)

--- a/SilentPatchIII/SilentPatchIII.cpp
+++ b/SilentPatchIII/SilentPatchIII.cpp
@@ -14,7 +14,7 @@
 
 #include <array>
 #include <memory>
-#include <Shlwapi.h>
+#include <shlwapi.h>
 
 #include "Utils/ModuleList.hpp"
 #include "Utils/Patterns.h"

--- a/SilentPatchIII/SilentPatchIII.cpp
+++ b/SilentPatchIII/SilentPatchIII.cpp
@@ -602,7 +602,7 @@ __declspec(naked) void RadarBoundsCheckEntityBlip()
 extern char** ppUserFilesDir = AddressByVersion<char**>(0x580C16, 0x580F66, 0x580E66);
 
 static LARGE_INTEGER	FrameTime;
-__declspec(safebuffers) int32_t GetTimeSinceLastFrame()
+NOBUFFERCHECKS int32_t GetTimeSinceLastFrame()
 {
 	LARGE_INTEGER	curTime;
 	QueryPerformanceCounter(&curTime);

--- a/SilentPatchIII/SilentPatchIII.cpp
+++ b/SilentPatchIII/SilentPatchIII.cpp
@@ -765,7 +765,7 @@ namespace Localization
 // ============= Call cDMAudio::IsAudioInitialised before adding one shot sounds, like in VC =============
 namespace AudioInitializedFix
 {
-	auto IsAudioInitialised = static_cast<bool(*)()>(Memory::ReadCallFrom( hook::get_pattern( "E8 ? ? ? ? 84 C0 74 ? 0F B7 47 10" ) ));
+	auto IsAudioInitialised = reinterpret_cast<bool(*)()>(Memory::ReadCallFrom( hook::get_pattern( "E8 ? ? ? ? 84 C0 74 ? 0F B7 47 10" ) ));
 	void* (*operatorNew)(size_t size);
 
 	void* operatorNew_InitializedCheck( size_t size )

--- a/SilentPatchIII/SilentPatchIII.cpp
+++ b/SilentPatchIII/SilentPatchIII.cpp
@@ -1692,6 +1692,8 @@ namespace SubtitleRadarCutoutFix
 	static const float* orgRadarWidth;
 	static const float* orgRadarBorderWidth;
 
+	static bool* bWideScreenOn;
+
 	template<std::size_t... I>
 	static void RecalculateValues(std::index_sequence<I...>)
 	{
@@ -1710,7 +1712,6 @@ namespace SubtitleRadarCutoutFix
 		}
 	}
 
-	static bool* bWideScreenOn;
 	static float fExtraSubtitleYOffset;
 
 	static void (*orgSetCentreSize)(float size);

--- a/SilentPatchIII/SilentPatchIII.cpp
+++ b/SilentPatchIII/SilentPatchIII.cpp
@@ -414,6 +414,7 @@ namespace M16StatsFix
 static const float fMinusOne = -1.0f;
 __declspec(naked) void HeadlightsFix()
 {
+#ifdef _MSC_VER
 	_asm
 	{
 		fld		dword ptr [esp+0x708-0x690]
@@ -431,6 +432,27 @@ __declspec(naked) void HeadlightsFix()
 		fld		st
 		jmp		HeadlightsFix_JumpBack
 	}
+#else
+	__asm__ volatile
+	(
+		"fld	dword ptr [esp+0x708-0x690]\n"
+		"fcomp	%[fMinusOne]\n"
+		"fnstsw	ax\n"
+		"and	ah, 5\n"
+		"cmp	ah, 1\n"
+		"jnz	HeadlightsFix_DontLimit\n"
+		"fld	%[fMinusOne]\n"
+		"fstp	dword ptr [esp+0x708-0x690]\n"
+
+"HeadlightsFix_DontLimit:\n"
+		"fld	dword ptr [esp+0x708-0x690]\n"
+		"fabs\n"
+		"fld	st\n"
+		"jmp	%[HeadlightsFix_JumpBack]"
+		:: [fMinusOne] "f" (fMinusOne),
+		[HeadlightsFix_JumpBack] "m" (HeadlightsFix_JumpBack)
+	);
+#endif
 }
 
 namespace PrintStringShadows
@@ -539,6 +561,7 @@ namespace MouseSensNewGame
 	static float DefaultHorizontalAccel, DefaultVerticalAccel;
 	__declspec(naked) void CameraInit_KeepSensitivity()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			mov     ecx, 0x3A76
@@ -550,6 +573,19 @@ namespace MouseSensNewGame
 			fstp	[ebp]CCamera.m_horizontalAccel
 			ret
 		}
+#else
+		__asm__ volatile
+		(
+			"mov	ecx, 0x3A76\n"
+			"mov	edi, ebp\n"
+			"fld	dword ptr [ebp+0x194]\n" // CCamera.m_horizontalAccel
+			"fld	dword ptr [ebp+0x198]\n" // CCamera.m_verticalAccel
+			"rep	stosd\n"
+			"fstp	dword ptr [ebp+0x198]\n" // CCamera.m_verticalAccel
+			"fstp	dword ptr [ebp+0x194]\n" // CCamera.m_horizontalAccel
+			"ret"
+		);
+#endif
 	}
 
 	static void (__thiscall *orgCtorCameraInit)(CCamera* obj);
@@ -565,6 +601,7 @@ static void* RadarBoundsCheckCoordBlip_JumpBack = AddressByVersion<void*>(0x4A55
 static void* RadarBoundsCheckCoordBlip_Count = AddressByVersion<void*>(0x4A55AF, 0x4A569F, 0x4A562F);
 __declspec(naked) void RadarBoundsCheckCoordBlip()
 {
+#ifdef _MSC_VER
 	_asm
 	{
 		mov		edx, RadarBoundsCheckCoordBlip_Count
@@ -579,11 +616,30 @@ __declspec(naked) void RadarBoundsCheckCoordBlip()
 		fcompp
 		ret
 	}
+#else
+	__asm__ volatile
+	(
+		"mov	edx, %[RadarBoundsCheckCoordBlip_Count]\n"
+		"cmp	cl, byte ptr [edx]\n"
+		"jnb	OutOfBounds\n"
+		"mov    edx, ecx\n"
+		"mov    eax, [esp+4]\n"
+		"jmp	%[RadarBoundsCheckCoordBlip_JumpBack]\n"
+
+"OutOfBounds:\n"
+		"or		eax, -1\n"
+		"fcompp\n"
+		"ret"
+		:: [RadarBoundsCheckCoordBlip_Count] "m" (RadarBoundsCheckCoordBlip_Count),
+		[RadarBoundsCheckCoordBlip_JumpBack] "m" (RadarBoundsCheckCoordBlip_JumpBack)
+	);
+#endif
 }
 
 static void* RadarBoundsCheckEntityBlip_JumpBack = AddressByVersion<void*>(0x4A565E, 0x4A574E, 0x4A56DE);
 __declspec(naked) void RadarBoundsCheckEntityBlip()
 {
+#ifdef _MSC_VER
 	_asm
 	{
 		mov		edx, RadarBoundsCheckCoordBlip_Count
@@ -597,6 +653,23 @@ __declspec(naked) void RadarBoundsCheckEntityBlip()
 		or		eax, -1
 		ret
 	}
+#else
+	__asm__ volatile
+	(
+		"mov	edx, %[RadarBoundsCheckCoordBlip_Count]\n"
+		"cmp	cl, byte ptr [edx]\n"
+		"jnb	OutOfBounds2\n"
+		"mov    edx, ecx\n"
+		"mov    eax, [esp+4]\n"
+		"jmp	%[RadarBoundsCheckEntityBlip_JumpBack]\n"
+
+		"OutOfBounds2:\n"
+		"or		eax, -1\n"
+		"ret"
+		:: [RadarBoundsCheckCoordBlip_Count] "m" (RadarBoundsCheckCoordBlip_Count),
+		[RadarBoundsCheckEntityBlip_JumpBack] "m" (RadarBoundsCheckEntityBlip_JumpBack)
+	);
+#endif
 }
 
 char** ppUserFilesDir = AddressByVersion<char**>(0x580C16, 0x580F66, 0x580E66);
@@ -635,6 +708,7 @@ unsigned int __cdecl AutoPilotTimerCalculation_III(unsigned int nTimer, int nSca
 
 __declspec(naked) void AutoPilotTimerFix_III()
 {
+#ifdef _MSC_VER
 	_asm
 	{
 		push    dword ptr [esp + 0x4]
@@ -649,6 +723,23 @@ __declspec(naked) void AutoPilotTimerFix_III()
 		pop     ebx
 		ret     4
 	}
+#else
+	__asm__ volatile
+	(
+		"push	dword ptr [esp + 0x4]\n"
+		"push	dword ptr [ebx + 0x10]\n"
+		"push	eax\n"
+		"call	%[AutoPilotTimerCalculation_III]\n"
+		"add	esp, 0xC\n"
+		"mov	[ebx + 0xC], eax\n"
+		"add	esp, 0x28\n"
+		"pop	ebp\n"
+		"pop	esi\n"
+		"pop	ebx\n"
+		"ret	4"
+		:: [AutoPilotTimerCalculation_III] "i" (AutoPilotTimerCalculation_III)
+	);
+#endif
 }
 
 namespace ZeroAmmoFix
@@ -803,6 +894,7 @@ namespace RemoveDriverStatusFix
 	{
 		// if (m_nStatus != STATUS_WRECKED)
 		//   m_nStatus = STATUS_ABANDONED;
+#ifdef _MSC_VER
 		_asm
 		{
 			mov		ah, [ecx+0x50]
@@ -816,6 +908,21 @@ namespace RemoveDriverStatusFix
 		DontSetStatus:
 			ret
 		}
+#else
+		__asm__ volatile
+		(
+			"mov	ah, [ecx+0x50]\n"
+			"mov	al, ah\n"
+			"and	ah, 0xF8\n"
+			"cmp	ah, 0x28\n"
+			"je		DontSetStatus\n"
+			"and    al, 7\n"
+			"or     al, 0x20\n"
+
+		"DontSetStatus:\n"
+			"ret"
+		);
+#endif
 	}
 }
 
@@ -848,6 +955,7 @@ namespace EvasiveDiveFix
 
 	__declspec(naked) static void CalculateAngle_Hook()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			push    dword ptr [esi+0x7C]
@@ -858,6 +966,19 @@ namespace EvasiveDiveFix
 			mov     ecx, ebp
 			ret
 		}
+#else
+		__asm__ volatile
+		(
+			"push	dword ptr [esi+0x7C]\n"
+			"push	dword ptr [esi+0x78]\n"
+			"call	%[CalculateAngle]\n"
+			"add	esp, 8\n"
+
+			"mov	ecx, ebp\n"
+			"ret"
+			:: [CalculateAngle] "i" (CalculateAngle)
+		);
+#endif
 	}
 }
 
@@ -870,27 +991,48 @@ namespace NullTerminatedLines
 	static void* orgSscanf_LoadPath;
 	__declspec(naked) static void sscanf1_LoadPath_Terminate()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			mov		eax, [esp+4]
 			mov		byte ptr [eax+ecx], 0
 			jmp		orgSscanf_LoadPath
 		}
+#else
+		__asm__ volatile
+		(
+			"mov	eax, [esp+4]\n"
+			"mov	byte ptr [eax+ecx], 0\n"
+			"jmp	%[orgSscanf_LoadPath]"
+			:: [orgSscanf_LoadPath] "m" (orgSscanf_LoadPath)
+		);
+#endif
 	}
 
 	static void* orgSscanf1;
 	__declspec(naked) static void sscanf1_Terminate()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			mov		eax, [esp+4]
 			mov		byte ptr [eax+ecx], 0
 			jmp		orgSscanf1
 		}
+#else
+		__asm__ volatile
+		(
+			"mov	eax, [esp+4]\n"
+			"mov	byte ptr [eax+ecx], 0\n"
+			"jmp	%[orgSscanf1]"
+			:: [orgSscanf1] "m" (orgSscanf1)
+		);
+#endif
 	}
 
 	__declspec(naked) static void ReadTrackFile_Terminate()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			mov		ecx, gString
@@ -900,6 +1042,18 @@ namespace NullTerminatedLines
 			add     ecx, [esp+0xAC-0x98]
 			ret
 		}
+#else
+		__asm__ volatile
+		(
+			"mov	ecx, %[gString]\n"
+			"mov	byte ptr [ecx+edx], 0\n"
+			"mov	ecx, [esi]\n"
+			"inc	ebp\n"
+			"add	ecx, [esp+0xAC-0x98]\n"
+			"ret"
+			:: [gString] "m" (gString)
+		);
+#endif
 	}
 }
 
@@ -926,6 +1080,7 @@ namespace DodoKeyboardControls
 	static void* (*orgFindPlayerVehicle)();
 	__declspec(naked) static void FindPlayerVehicle_DodoCheck()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			call	orgFindPlayerVehicle
@@ -937,6 +1092,21 @@ namespace DodoKeyboardControls
 		CheatDisabled:
 			ret
 		}
+#else
+		__asm__ volatile
+		(
+			"call	%[orgFindPlayerVehicle]\n"
+			"mov	ecx, %[bAllDodosCheat]\n"
+			"cmp	byte ptr [ecx], 0\n"
+			"je		CheatDisabled\n"
+			"mov	byte ptr [esp+0x1C-0x14], 1\n"
+
+		"CheatDisabled:\n"
+			"ret"
+			:: [orgFindPlayerVehicle] "m" (orgFindPlayerVehicle),
+			[bAllDodosCheat] "m" (bAllDodosCheat)
+		);
+#endif
 	}
 }
 
@@ -1005,6 +1175,7 @@ namespace GenerateNewPickup_ReuseObjectFix
 
 	__declspec(naked) static void GiveUsAPickUpObject_CleanUpObject()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			mov		eax, pPickupObject
@@ -1030,6 +1201,36 @@ namespace GenerateNewPickup_ReuseObjectFix
 		NoPickup:
 			jmp		orgGiveUsAPickUpObject
 		}
+#else
+		__asm__ volatile
+		(
+			"mov	eax, %[pPickupObject]\n"
+			"add	eax, ebp\n"
+			"mov	eax, [eax]\n"
+			"test	eax, eax\n"
+			"jz		NoPickup\n"
+			"push	edi\n"
+			"mov	edi, eax\n"
+
+			"push	edi\n"
+			"call	offset %[WorldRemove]\n"
+			"add	esp, 4\n"
+
+			// Call dtor
+			"mov	ecx, edi\n"
+			"mov	eax, [edi]\n"
+			"push	1\n"
+			"call	dword ptr [eax]\n"
+
+			"pop	edi\n"
+
+		"NoPickup:\n"
+			"jmp	%[orgGiveUsAPickUpObject]"
+			:: [pPickupObject] "m" (pPickupObject),
+			[WorldRemove] "m" (WorldRemove),
+			[orgGiveUsAPickUpObject] "m" (orgGiveUsAPickUpObject)
+		);
+#endif
 	}
 }
 

--- a/SilentPatchIII/SilentPatchIII.cpp
+++ b/SilentPatchIII/SilentPatchIII.cpp
@@ -599,7 +599,7 @@ __declspec(naked) void RadarBoundsCheckEntityBlip()
 	}
 }
 
-extern char** ppUserFilesDir = AddressByVersion<char**>(0x580C16, 0x580F66, 0x580E66);
+char** ppUserFilesDir = AddressByVersion<char**>(0x580C16, 0x580F66, 0x580E66);
 
 static LARGE_INTEGER	FrameTime;
 NOBUFFERCHECKS int32_t GetTimeSinceLastFrame()

--- a/SilentPatchSA/AudioHardwareSA.h
+++ b/SilentPatchSA/AudioHardwareSA.h
@@ -2,7 +2,7 @@
 #define __AUDIOHARDWARE
 
 // IStream
-#include <Objidl.h>
+#include <objidl.h>
 
 enum eDecoderType
 {

--- a/SilentPatchSA/FLACDecoderSA.h
+++ b/SilentPatchSA/FLACDecoderSA.h
@@ -3,8 +3,8 @@
 #include "AudioHardwareSA.h"
 
 // libflac
-#include "FLAC\stream_decoder.h"
-#include "FLAC\metadata.h"
+#include "FLAC/stream_decoder.h"
+#include "FLAC/metadata.h"
 
 class CAEFLACDecoder final : public CAEStreamingDecoder
 {

--- a/SilentPatchSA/GeneralSA.h
+++ b/SilentPatchSA/GeneralSA.h
@@ -2,6 +2,7 @@
 #define __GENERAL
 
 #include <stdint.h>
+#include "Common.h"
 #include "TheFLAUtils.h"
 
 class CSimpleTransform

--- a/SilentPatchSA/SilentPatchSA.cpp
+++ b/SilentPatchSA/SilentPatchSA.cpp
@@ -1214,7 +1214,7 @@ char* GetMyDocumentsPathSA()
 }
 
 static LARGE_INTEGER	FrameTime;
-__declspec(safebuffers) int32_t GetTimeSinceLastFrame()
+NOBUFFERCHECKS int32_t GetTimeSinceLastFrame()
 {
 	LARGE_INTEGER	curTime;
 	QueryPerformanceCounter(&curTime);
@@ -4320,7 +4320,7 @@ __declspec(naked) void DarkVehiclesFix4()
 }
 // 1.0 ONLY ENDS HERE
 
-__declspec(safebuffers) static int _Timers_ftol_internal( double timer, double& remainder )
+NOBUFFERCHECKS static int _Timers_ftol_internal( double timer, double& remainder )
 {
 	double integral;
 	remainder = modf( timer + remainder, &integral );

--- a/SilentPatchSA/SilentPatchSA.cpp
+++ b/SilentPatchSA/SilentPatchSA.cpp
@@ -2,9 +2,9 @@
 #include <algorithm>
 #include <array>
 #include <d3d9.h>
-#include <Shlwapi.h>
-#include <ShlObj.h>
-#include <ShellAPI.h>
+#include <shlwapi.h>
+#include <shlobj.h>
+#include <shellapi.h>
 #include <cinttypes>
 
 #include "AnimationSA.h"

--- a/SilentPatchSA/SilentPatchSA.cpp
+++ b/SilentPatchSA/SilentPatchSA.cpp
@@ -3160,7 +3160,7 @@ namespace CreditsScalingFixes
 	static const unsigned int FIXED_RES_HEIGHT_SCALE = 448;
 
 	template<std::size_t Index>
-	static void (*orgPrintString)(float,float,const wchar_t*);
+	STATIC_INLINE void (*orgPrintString)(float,float,const wchar_t*);
 
 	template<std::size_t Index>
 	static void PrintString_ScaleY(float fX, float fY, const wchar_t* pText)
@@ -3200,7 +3200,7 @@ namespace SlidingTextsScalingFixes
 		static inline bool bSlidingEnabled = false;
 
 		template<std::size_t Index>
-		static void (*orgPrintString)(float,float,const wchar_t*);
+		STATIC_INLINE void (*orgPrintString)(float,float,const wchar_t*);
 
 		template<std::size_t Index>
 		static void PrintString_Slide(float fX, float fY, const wchar_t* pText)
@@ -3210,7 +3210,7 @@ namespace SlidingTextsScalingFixes
 		}
 
 		template<std::size_t Index>
-		static void (*orgSetRightJustifyWrap)(float wrap);
+		STATIC_INLINE void (*orgSetRightJustifyWrap)(float wrap);
 
 		template<std::size_t Index>
 		static void SetRightJustifyWrap_Slide(float wrap)
@@ -3227,7 +3227,7 @@ namespace SlidingTextsScalingFixes
 		static inline bool bSlidingEnabled = false;
 
 		template<std::size_t Index>
-		static void (*orgPrintString)(float,float,const wchar_t*);
+		STATIC_INLINE void (*orgPrintString)(float,float,const wchar_t*);
 
 		template<std::size_t Index>
 		static void PrintString_Slide(float fX, float fY, const wchar_t* pText)
@@ -3588,7 +3588,7 @@ namespace FixedLineWraps
 	struct WrapInternal
 	{
 		template<std::size_t Index>
-		static void (*orgWrapFunction)(float);
+		STATIC_INLINE void (*orgWrapFunction)(float);
 
 		template<std::size_t Index>
 		static void WrapFunction_LeftAlign(float fLength)

--- a/SilentPatchSA/SilentPatchSA.cpp
+++ b/SilentPatchSA/SilentPatchSA.cpp
@@ -8242,7 +8242,7 @@ void Patch_SA_NewBinaries_Common(HINSTANCE hInstance)
 	// Fixed escalators crash
 	try
 	{
-		orgEscalatorsUpdate = static_cast<decltype(orgEscalatorsUpdate)>(get_pattern( "80 3D ? ? ? ? ? 74 23 56" ));
+		orgEscalatorsUpdate = reinterpret_cast<decltype(orgEscalatorsUpdate)>(get_pattern( "80 3D ? ? ? ? ? 74 23 56" ));
 
 		auto updateEscalators = get_pattern("80 3D ? ? ? ? ? 74 22 56");
 		auto removeEscalatorsForEntity = pattern( "80 7E F5 00 74 56" ).get_one();
@@ -9112,7 +9112,7 @@ void Patch_SA_NewBinaries_Common(HINSTANCE hInstance)
 		ppRWD3D9 = *get_pattern<IDirect3D9**>("33 ED A3 ? ? ? ? 3B C5", 2 + 1);
 		FrontEndMenuManager = *get_pattern<void**>("50 50 68 ? ? ? ? B9 ? ? ? ? E8", 7 + 1); // This has 2 identical matches, we just need one
 
-		orgGetDocumentsPath = static_cast<char*(*)()>(get_pattern( "8D 45 FC 50 68 19 00 02 00", -6 ));
+		orgGetDocumentsPath = reinterpret_cast<char*(*)()>(get_pattern( "8D 45 FC 50 68 19 00 02 00", -6 ));
 
 		Patch(dialogBoxParam, &pDialogBoxParamA_New);
 		Patch(setFocus, &pSetFocus_NOP);

--- a/SilentPatchSA/VehicleSA.h
+++ b/SilentPatchSA/VehicleSA.h
@@ -299,7 +299,7 @@ public:
 
 private:
 	template<std::size_t Index>
-	static void (CVehicle::*orgDoHeadLightBeam)(int type, CMatrix& m, bool right);
+	STATIC_INLINE void (CVehicle::*orgDoHeadLightBeam)(int type, CMatrix& m, bool right);
 
 	template<std::size_t Index>
 	void DoHeadLightBeam_LightBeamFixSaveObj(int type, CMatrix& m, bool right)
@@ -334,7 +334,7 @@ public:
 
 public:
 	template<std::size_t Index>
-	static void (CAutomobile::*orgAutomobilePreRender)();
+	STATIC_INLINE void (CAutomobile::*orgAutomobilePreRender)();
 
 	template<std::size_t Index>
 	void		PreRender_SilentPatch()
@@ -349,7 +349,7 @@ public:
 	void HideDestroyedWheels_SilentPatch(void (CAutomobile::*spawnFlyingComponentCB)(int, unsigned int), int nodeID, unsigned int modelID);
 
 	template<std::size_t Index>
-	static void (CAutomobile::*orgSpawnFlyingComponent)(int, unsigned int);
+	STATIC_INLINE void (CAutomobile::*orgSpawnFlyingComponent)(int, unsigned int);
 
 	template<std::size_t Index>
 	void		SpawnFlyingComponent_HideWheels(int nodeID, unsigned int modelID)
@@ -445,7 +445,7 @@ private:
 
 private:
 	template<std::size_t Index>
-	static CVehicle* (CStoredCar::*orgRestoreCar)();
+	STATIC_INLINE CVehicle* (CStoredCar::*orgRestoreCar)();
 
 	template<std::size_t Index>
 	CVehicle* RestoreCar_SilentPatch()

--- a/SilentPatchVC/SilentPatchVC.cpp
+++ b/SilentPatchVC/SilentPatchVC.cpp
@@ -542,7 +542,7 @@ namespace RadarTraceOutlineFixes
 		}
 
 		template<std::size_t Index>
-		static void (*orgShowRadarTraceWithHeight)(float, float, unsigned int, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char);
+		STATIC_INLINE void (*orgShowRadarTraceWithHeight)(float, float, unsigned int, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char);
 
 		template<std::size_t Index>
 		static void ShowRadarTraceWithHeight_RecalculatePositions(float a1, float a2, unsigned int a3, unsigned char a4, unsigned char a5, unsigned char a6, unsigned char a7, unsigned char a8)
@@ -642,7 +642,7 @@ namespace SlidingTextsScalingFixes
 		static inline bool bSlidingEnabled = false;
 
 		template<std::size_t Index>
-		static void (*orgPrintString)(float,float,const wchar_t*);
+		STATIC_INLINE void (*orgPrintString)(float,float,const wchar_t*);
 
 		template<std::size_t Index>
 		static void PrintString_Slide(float fX, float fY, const wchar_t* pText)
@@ -652,7 +652,7 @@ namespace SlidingTextsScalingFixes
 		}
 
 		template<std::size_t Index>
-		static void (*orgSetRightJustifyWrap)(float wrap);
+		STATIC_INLINE void (*orgSetRightJustifyWrap)(float wrap);
 
 		template<std::size_t Index>
 		static void SetRightJustifyWrap_Slide(float wrap)
@@ -669,7 +669,7 @@ namespace SlidingTextsScalingFixes
 		static inline bool bSlidingEnabled = false;
 
 		template<std::size_t Index>
-		static void (*orgPrintString)(float,float,const wchar_t*);
+		STATIC_INLINE void (*orgPrintString)(float,float,const wchar_t*);
 
 		template<std::size_t Index>
 		static void PrintString_Slide(float fX, float fY, const wchar_t* pText)
@@ -930,7 +930,7 @@ namespace FixedLineWraps
 	struct WrapInternal
 	{
 		template<std::size_t Index>
-		static void (*orgWrapFunction)(float);
+		STATIC_INLINE void (*orgWrapFunction)(float);
 
 		template<std::size_t Index>
 		static void WrapFunction_LeftAlign(float fLength)

--- a/SilentPatchVC/SilentPatchVC.cpp
+++ b/SilentPatchVC/SilentPatchVC.cpp
@@ -1046,7 +1046,7 @@ __declspec(naked) void CreateInstance_BikeFix()
 	}
 }
 
-extern char** ppUserFilesDir = AddressByVersion<char**>(0x6022AA, 0x60228A, 0x601ECA);
+char** ppUserFilesDir = AddressByVersion<char**>(0x6022AA, 0x60228A, 0x601ECA);
 
 static LARGE_INTEGER	FrameTime;
 NOBUFFERCHECKS int32_t GetTimeSinceLastFrame()

--- a/SilentPatchVC/SilentPatchVC.cpp
+++ b/SilentPatchVC/SilentPatchVC.cpp
@@ -1035,8 +1035,15 @@ float FixedRefValue()
 	return 1.0f;
 }
 
+// C-style wrapper for calling a C++ function in GCC-style inline assembly (the function signature is really important here)
+RwFrame* __thiscall CVehicleModelInfo_GetExtrasFrame(CVehicleModelInfo* modelInfo, RpClump* clump)
+{
+	return modelInfo->GetExtrasFrame(clump);
+}
+
 __declspec(naked) void CreateInstance_BikeFix()
 {
+#ifdef _MSC_VER
 	_asm
 	{
 		push	eax
@@ -1044,6 +1051,16 @@ __declspec(naked) void CreateInstance_BikeFix()
 		call	CVehicleModelInfo::GetExtrasFrame
 		ret
 	}
+#else
+	__asm__ volatile
+	(
+		"push	eax\n"
+		"mov	ecx, ebp\n"
+		"call	%[CVehicleModelInfo_GetExtrasFrame]\n"
+		"ret"
+		:: [CVehicleModelInfo_GetExtrasFrame] "i" (CVehicleModelInfo_GetExtrasFrame)
+	);
+#endif
 }
 
 char** ppUserFilesDir = AddressByVersion<char**>(0x6022AA, 0x60228A, 0x601ECA);
@@ -1083,6 +1100,7 @@ unsigned int __cdecl AutoPilotTimerCalculation_VC(unsigned int nTimer, int nScal
 
 __declspec(naked) void AutoPilotTimerFix_VC()
 {
+#ifdef _MSC_VER
 	_asm
 	{
 		push	dword ptr [esp + 0xC]
@@ -1096,6 +1114,22 @@ __declspec(naked) void AutoPilotTimerFix_VC()
 		pop     ebx
 		ret     4
 	}
+#else
+	__asm__ volatile
+	(
+		"push	dword ptr [esp + 0xC]\n"
+		"push	dword ptr [ebx + 0x10]\n"
+		"push	eax\n"
+		"call	%[AutoPilotTimerCalculation_VC]\n"
+		"add	esp, 0xC\n"
+		"mov	[ebx + 0xC], eax\n"
+		"add	esp, 0x30\n"
+		"pop	ebp\n"
+		"pop	ebx\n"
+		"ret	4"
+		:: [AutoPilotTimerCalculation_VC] "i" (AutoPilotTimerCalculation_VC)
+	);
+#endif
 }
 
 
@@ -1216,6 +1250,7 @@ namespace SirenSwitchingFix
 {
 	__declspec(naked) static void IsFBIRanchOrFBICar()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			mov     dword ptr [esi+0x1C], 0x1C
@@ -1232,6 +1267,24 @@ namespace SirenSwitchingFix
 			xor     al, al
 			ret
 		}
+#else
+		__asm__ volatile
+		(
+			"mov    dword ptr [esi+0x1C], 0x1C\n"
+
+			// al = 0 - high pitched siren
+			// al = 1 - normal siren
+			"cmp    dword ptr [ebp+0x14], 90\n"	// fbiranch
+			"je     IsFBIRanchOrFBICar_HighPitchSiren\n"
+			"cmp    dword ptr [ebp+0x14], 17\n"	// fbicar
+			"setne  al\n"
+			"ret\n"
+
+		"IsFBIRanchOrFBICar_HighPitchSiren:\n"
+			"xor    al, al\n"
+			"ret"
+		);
+#endif
 	}
 }
 
@@ -1300,6 +1353,7 @@ namespace RemoveDriverStatusFix
 	{
 		// if (m_nStatus != STATUS_WRECKED)
 		//   m_nStatus = STATUS_ABANDONED;
+#ifdef _MSC_VER
 		_asm
 		{
 			mov		cl, [ebx+0x50]
@@ -1313,6 +1367,21 @@ namespace RemoveDriverStatusFix
 		DontSetStatus:
 			ret
 		}
+#else
+		__asm__ volatile
+		(
+			"mov	cl, [ebx+0x50]\n"
+			"mov	al, cl\n"
+			"and	cl, 0xF8\n"
+			"cmp	cl, 0x28\n"
+			"je		DontSetStatus\n"
+			"and    al, 7\n"
+			"or     al, 0x20\n"
+
+		"DontSetStatus:\n"
+			"ret"
+		);
+#endif
 	}
 }
 
@@ -1385,12 +1454,22 @@ namespace NullTerminatedLines
 	static void* orgSscanf_LoadPath;
 	__declspec(naked) static void sscanf1_LoadPath_Terminate()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			mov		eax, [esp+4]
 			mov		byte ptr [eax+ecx], 0
 			jmp		orgSscanf_LoadPath
 		}
+#else
+		__asm__ volatile
+		(
+			"mov	eax, [esp+4]\n"
+			"mov	byte ptr [eax+ecx], 0\n"
+			"jmp	%[orgSscanf_LoadPath]"
+			:: [orgSscanf_LoadPath] "m" (orgSscanf_LoadPath)
+		);
+#endif
 	}
 }
 
@@ -1415,16 +1494,26 @@ namespace PickupEffectsFixes
 {
 	__declspec(naked) static void PickUpEffects_BigDollarColor()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			mov		byte ptr [esp+0x184-0x170], 0
 			mov		dword ptr [esp+0x184-0x174], 37
 			ret
 		}
+#else
+		__asm__ volatile
+		(
+			"mov	byte ptr [esp+0x184-0x170], 0\n"
+			"mov	dword ptr [esp+0x184-0x174], 37\n"
+			"ret"
+		);
+#endif
 	}
 
 	__declspec(naked) static void PickUpEffects_Minigun2Glow()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			cmp		ecx, 294	// minigun2
@@ -1440,6 +1529,23 @@ namespace PickupEffectsFixes
 			mov     ebx, ecx
 			ret
 		}
+#else
+		__asm__ volatile
+		(
+			"cmp	ecx, 294\n"	// minigun2
+			"jnz	NotMinigun2\n"
+			"mov	byte ptr [esp+0x184-0x170], 0\n"
+			"xor	eax, eax\n"
+			"jmp	Return\n"
+
+		"NotMinigun2:\n"
+			"lea    eax, [ecx+1]\n"
+
+		"Return:\n"
+			"mov    ebx, ecx\n"
+			"ret"
+		);
+#endif
 	}
 }
 
@@ -1456,6 +1562,7 @@ namespace IsPlayerTargettingCharFix
 	__declspec(naked) static void IsPlayerTargettingChar_ExtraChecks()
 	{
 		// After this extra block of code, there is a jz Return, so set ZF to 0 here if this path is to be entered
+#ifdef _MSC_VER
 		_asm
 		{
 			test	bl, bl
@@ -1476,6 +1583,31 @@ namespace IsPlayerTargettingCharFix
 			xor		al, al
 			ret
 		}
+#else
+		__asm__ volatile
+		(
+			"test	bl, bl\n"
+			"jnz	ReturnToUpdateCompareFlag\n"
+			"mov	eax, %[bUseMouse3rdPerson]\n"
+			"cmp	byte ptr [eax], 0\n"
+			"jne	CmpAndReturn\n"
+			"mov	ecx, %[TheCamera]\n"
+			"call	%[Using1stPersonWeaponMode]\n"
+			"test	al, al\n"
+			"jz		ReturnToUpdateCompareFlag\n"
+
+		"CmpAndReturn:\n"
+			"cmp    byte ptr [esp+0x11C-0x10C], 0\n"
+			"ret\n"
+
+		"ReturnToUpdateCompareFlag:\n"
+			"xor	al, al\n"
+			"ret"
+			:: [bUseMouse3rdPerson] "m" (bUseMouse3rdPerson),
+			[TheCamera] "m" (TheCamera),
+			[Using1stPersonWeaponMode] "m" (Using1stPersonWeaponMode)
+		);
+#endif
 	}
 }
 
@@ -1617,6 +1749,7 @@ namespace SelectableBackfaceCulling
 	static void* EntityRender_Prologue_JumpBack;
 	__declspec(naked) static void __fastcall EntityRender_Original(CEntity*)
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			push    ebx
@@ -1624,6 +1757,16 @@ namespace SelectableBackfaceCulling
 			cmp     dword ptr [ebx+0x4C], 0
 			jmp		EntityRender_Prologue_JumpBack
 		}
+#else
+		__asm__ volatile
+		(
+			"push   ebx\n"
+			"mov    ebx, ecx\n"
+			"cmp    dword ptr [ebx+0x4C], 0\n"
+			"jmp	%[EntityRender_Prologue_JumpBack]"
+			:: [EntityRender_Prologue_JumpBack] "m" (EntityRender_Prologue_JumpBack)
+		);
+#endif
 	}
 
 	static bool ShouldDisableBackfaceCulling(const CEntity* entity)
@@ -1768,11 +1911,20 @@ namespace PedMugObjectiveFix
 	static void* PedMugObjectiveFix_JumpBack;
 	__declspec(naked) static void PedMugObjectiveFix_Wander()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			mov     eax, [ebp+534h]
 			jmp		[PedMugObjectiveFix_JumpBack]
 		}
+#else
+		__asm__ volatile
+		(
+			"mov    eax, [ebp+0x534]\n"
+			"jmp	%[PedMugObjectiveFix_JumpBack]"
+			:: [PedMugObjectiveFix_JumpBack] "m" (PedMugObjectiveFix_JumpBack)
+		);
+#endif
 	}
 }
 
@@ -1841,6 +1993,7 @@ namespace TommyFistShakeWithWeapons
 
 	__declspec(naked) static void CheckWeaponGroupHook()
 	{
+#ifdef _MSC_VER
 		_asm
 		{
 			push	dword ptr [eax]
@@ -1849,6 +2002,17 @@ namespace TommyFistShakeWithWeapons
 			test	al, al
 			ret
 		}
+#else
+		__asm__ volatile
+		(
+			"push	dword ptr [eax]\n"
+			"call	%[WeaponProhibitsFistShake]\n"
+			"add	esp, 4\n"
+			"test	al, al\n"
+			"ret"
+			:: [WeaponProhibitsFistShake] "i" (WeaponProhibitsFistShake)
+		);
+#endif
 	}
 
 	template<std::size_t Index>

--- a/SilentPatchVC/SilentPatchVC.cpp
+++ b/SilentPatchVC/SilentPatchVC.cpp
@@ -17,7 +17,7 @@
 #include <array>
 #include <limits>
 #include <memory>
-#include <Shlwapi.h>
+#include <shlwapi.h>
 #include <time.h>
 
 #include "Utils/ModuleList.hpp"

--- a/SilentPatchVC/SilentPatchVC.cpp
+++ b/SilentPatchVC/SilentPatchVC.cpp
@@ -2346,7 +2346,7 @@ void InjectDelayedPatches_VC_Common( bool bHasDebugMenu, const wchar_t* wcModule
 
 
 		// Stuff to let us (re)initialize
-		static void (*HUDReInitialise)() = static_cast<decltype(HUDReInitialise)>(get_pattern("31 C0 53 0F EF C0 C6 05"));
+		static void (*HUDReInitialise)() = reinterpret_cast<decltype(HUDReInitialise)>(get_pattern("31 C0 53 0F EF C0 C6 05"));
 
 		// This pattern has 5 hits - first 2 are in Reinitialise, the rest is in Initialise
 		auto reinitialise1 = pattern("C7 05 ? ? ? ? 05 00 00 00 66 C7 05 ? ? ? ? 00 00 C7 05 ? ? ? ? 00 00 00 00").count(5);
@@ -3282,7 +3282,7 @@ void Patch_VC_Common()
 		using namespace IsPlayerTargettingCharFix;
 
 		auto isPlayerTargettingChar = pattern("83 7C 24 ? ? A3 ? ? ? ? 0F 84").get_one();
-		auto using1stPersonWeaponMode = static_cast<decltype(Using1stPersonWeaponMode)>(get_pattern("66 83 F8 07 74 18", -7));
+		auto using1stPersonWeaponMode = reinterpret_cast<decltype(Using1stPersonWeaponMode)>(get_pattern("66 83 F8 07 74 18", -7));
 		bool* useMouse3rdPerson = *get_pattern<bool*>("80 3D ? ? ? ? ? 75 09 66 C7 05 ? ? ? ? ? ? 8B 35", 2);
 		void* theCamera = *get_pattern<void*>("B9 ? ? ? ? 31 DB E8", 1);
 

--- a/SilentPatchVC/SilentPatchVC.cpp
+++ b/SilentPatchVC/SilentPatchVC.cpp
@@ -376,7 +376,7 @@ namespace PrintStringShadows
 		}
 	};
 
-	template<uintptr_t pFltY>
+	template<uintptr_t pFltY, typename Scaler>
 	struct Y
 	{
 		static inline void (*orgPrintString)(float,float,const wchar_t*);

--- a/SilentPatchVC/SilentPatchVC.cpp
+++ b/SilentPatchVC/SilentPatchVC.cpp
@@ -1049,7 +1049,7 @@ __declspec(naked) void CreateInstance_BikeFix()
 extern char** ppUserFilesDir = AddressByVersion<char**>(0x6022AA, 0x60228A, 0x601ECA);
 
 static LARGE_INTEGER	FrameTime;
-__declspec(safebuffers) int32_t GetTimeSinceLastFrame()
+NOBUFFERCHECKS int32_t GetTimeSinceLastFrame()
 {
 	LARGE_INTEGER	curTime;
 	QueryPerformanceCounter(&curTime);


### PR DESCRIPTION
This PR might be too large when compared to the ModUtils one (so I can split it if needed)

Compiling with MSVC isn't tested either (maybe I should try installing VS on Wine to avoid this testing void?; GitHub Actions would also help)

Note: Adding a different build system is required to actually use this work (#31 mentions Premake which might be okay here but Meson is an option too and it's used by some popular PE libraries like DXVK) so I'm currently using some hacky Makefiles (I might push those to a branch later)