### PR TITLE
III: Fix the missing window icon

### DIFF
--- a/CHANGELOG-III.md
+++ b/CHANGELOG-III.md
@@ -71,6 +71,7 @@ All the remaining, non-critical fixes.
 * Detached limbs now have properly working LODs, instead of rendering the normal and low-detail models at the same time.
 * Low Brightness options now load and save correctly, instead of reverting to overly bright values.
 * Support for the `brakelights` dummy has been restored, allowing brake and reverse lights to work as they did in the PS2 version, rather than always sharing the same placement with the tail lights.
+* The correct window icon is now displayed.
 * ⚙️ Fixed siren corona placements in Firetruck, Ambulance, and Enforcer.
 * ⚙️ Fixed taxi light corona placement for Taxi.
 * ⚙️ Fixed police chopper's searchlight placement.

--- a/SilentPatch/Common_ddraw.cpp
+++ b/SilentPatch/Common_ddraw.cpp
@@ -229,6 +229,16 @@ namespace Common {
 			}
 			TXN_CATCH();
 
+			// III: Patch the icon handle to fix missing window icon
+			// (This is fixed since VC)
+			try
+			{
+				auto addr = get_pattern("c7 44 24 1c 00 00 00 00 c7 44 24 08 00 20 00", 0x4);
+				HICON wndIconIII = LoadIconA(GetModuleHandleA(nullptr), MAKEINTRESOURCEA(0x412)); // Group icon ID
+
+				Patch<HICON>(addr, wndIconIII);
+			}
+			TXN_CATCH();
 
 			// No censorships
 			try


### PR DESCRIPTION
For some reason GTA 3 sets the hIcon value in WNDCLASSA struct to NULL which causes the window icon to be the default one (this was fixed in Vice City)

Fixes #117 