### PR TITLE
Disable text background fix for SAMP

### DIFF
--- a/SilentPatchSA/SilentPatchSA.cpp
+++ b/SilentPatchSA/SilentPatchSA.cpp
@@ -4742,6 +4742,7 @@ BOOL InjectDelayedPatches_10()
 		// Fix text background padding not scaling to resolution
 		// Debugged by Wesser
 		// Moved here for compatibility with wshps.asi
+		if (!bSAMP)
 		{
 			using namespace TextRectPaddingScalingFixes;
 


### PR DESCRIPTION
SAMP use font to draw some boxes in textdraws. The background padding fix is corrupt textdraws, what uses it.

### Without this PR
![demo corrupted textdrawes](https://github.com/user-attachments/assets/a6de4343-d083-462f-b5b0-523dfc5af289)

### With this PR (same without SilentPatch) - correct
![demo correct textdraw](https://github.com/user-attachments/assets/66889849-5f57-4d47-99a7-5097c17a21d0)
