### PR TITLE
Add minimal mipmapping support configurable via INI

### DIFF
--- a/CHANGELOG-VC.md
+++ b/CHANGELOG-VC.md
@@ -108,3 +108,4 @@ Any changes that don't strictly fix game bugs.
 * ⚙️ Sliding mission titles and odd job texts from the GTA III beta can now be re-enabled (off by default).
 * ⚙️ An unused 'Minimal HUD' feature can now be re-enabled (off by default).
 * ⚙️ Purchasable property icons now show on the radar and the menu map (off by default).
+* ⚙️ Mipmapping support can now be enabled, reducing aliasing and flickering on distant textures (contributed by **CanerKaraca**).

--- a/Config/SilentPatchVC.ini
+++ b/Config/SilentPatchVC.ini
@@ -32,6 +32,8 @@ ScaleScriptSprites=1
 ; Adjust the delay time between NPC comments
 ; Set -1 to make the game use default delay time (6000ms)
 SpeechDelayTimer=0
+; Enables mipmapping support for textures, reducing aliasing and shimmering on distant objects.
+EnableMipMaps=0
 
 [ExtraCompSpecularityExceptions]
 ; Put model IDs or names (one ID/name per line) here to forcibly disable specularity on their extras

--- a/SilentPatchVC/SilentPatchVC.cpp
+++ b/SilentPatchVC/SilentPatchVC.cpp
@@ -3298,6 +3298,27 @@ void InjectDelayedPatches_VC_Common( bool bHasDebugMenu, const wchar_t* wcModule
 	}
 	TXN_CATCH();
 
+	// Mipmapping
+	// Contributed by CanerKaraca
+	if (const int INIoption = GetPrivateProfileIntW(L"SilentPatch", L"EnableMipMaps", 0, wcModulePath); INIoption != 0) try
+	{
+		// Enable Mipmapping globally
+		// Matches: push 1; call RwTextureSetAutoMipmapping; add esp, 4; push 0
+		auto setMipmapping = pattern("6A 01 E8 ? ? ? ? 83 C4 ? 6A 00").get_first<uint8_t>();
+		if (setMipmapping)
+		{
+			// change push 0 to push 1
+			Patch<uint8_t>(setMipmapping + 10, 1);
+		}
+
+		// Remove code which disables mipmap flags in CStreaming::ReadTextureFormat
+		// Finds: and dword ptr [esp+XX], 0FFFF6FFFh followed by test
+		pattern("81 ? ? ? FF 6F FF FF 84").for_each_result([](hook::txn::pattern_match match) {
+			Nop(match.get<void>(0), 8);
+		});
+	}
+	TXN_CATCH();
+
 	// Speech delay fix
 	if (const int speech_delay = GetPrivateProfileIntW(L"SilentPatch", L"SpeechDelayTimer", -1, wcModulePath); speech_delay != -1) try
 	{


### PR DESCRIPTION
Closes https://github.com/CookiePLMonster/SilentPatch/issues/73

ViceMips is no longer needed, disabled by default.
Not tested on Steam version yet. There may be mistakes or AI slops, sorry, edits to PR is always welcomed. Thanks.