### PR TITLE
SA: Fix swapped GANGS and CRIMES section names in stats.html

### DIFF
--- a/CHANGELOG-SA.md
+++ b/CHANGELOG-SA.md
@@ -147,6 +147,7 @@ All the remaining, non-critical fixes.
 * ➕ Securicars are now tougher when damaged by the player.
 * ➕ A misplaced Beagle in Fort Carson has been replaced with a BMX.
 * ➕ Rhino now has fully functional lights (contributed by **rx**).
+* ➕ The GANGS and CRIMES section names are no longer swapped when exporting stats to stats.html.
 * Detached vehicle parts will now keep the same color and lighting as the vehicle they came from.
 * Detached vehicle parts are now rendered from both sides.
 * Resolved single-pixel wide seams showing on the Map screen with Anti-Aliasing enabled.

--- a/CHANGELOG-SA.md
+++ b/CHANGELOG-SA.md
@@ -147,7 +147,7 @@ All the remaining, non-critical fixes.
 * ➕ Securicars are now tougher when damaged by the player.
 * ➕ A misplaced Beagle in Fort Carson has been replaced with a BMX.
 * ➕ Rhino now has fully functional lights (contributed by **rx**).
-* ➕ The GANGS and CRIMES section names are no longer swapped when exporting stats to stats.html.
+* ➕ The GANGS and CRIMES section names are no longer swapped when exporting stats to stats.html (contributed by **sndth**).
 * Detached vehicle parts will now keep the same color and lighting as the vehicle they came from.
 * Detached vehicle parts are now rendered from both sides.
 * Resolved single-pixel wide seams showing on the Map screen with Anti-Aliasing enabled.

--- a/README.md
+++ b/README.md
@@ -46,5 +46,6 @@ SilentPatch includes code contributions from:
 * NTAuthority
 * rx
 * Sergeanur
+* sndth
 * spaceeinstein
 * Wesser

--- a/SilentPatchSA/SilentPatchSA.cpp
+++ b/SilentPatchSA/SilentPatchSA.cpp
@@ -11326,9 +11326,10 @@ void Patch_SA_NewBinaries_Common(HINSTANCE hInstance)
 	TXN_CATCH();
 
 
-	// Swap the GANGS and CRIMES section names when exporting stats to stats.html.
-	// Stat section 3 holds crime stats and section 4 holds gang stats, but the exporter labels them the other way around.
-	// The switch printing those names is located through the GXT keys it references, since its shape differs between the compilers the game versions were built with
+	// Swap the GANGS and CRIMES section names when exporting stats to stats.html. Stat section 3 holds crime
+	// stats and section 4 holds gang stats, but the exporter labels them the other way around.
+	// The switch printing those names is located through the GXT keys it references, since its shape differs
+	// between the compilers the game versions were built with
 	try
 	{
 		const hook::scan_segments rdata = hook::get_section_by_name(GetModuleHandle(nullptr), ".rdata");

--- a/SilentPatchSA/SilentPatchSA.cpp
+++ b/SilentPatchSA/SilentPatchSA.cpp
@@ -9303,6 +9303,34 @@ void Patch_SA_Steam()
 	InjectHook(0x5EDFD9, 0x5EE0FA, HookType::Jump);
 }
 
+// Formats raw bytes as an IDA style pattern, so no mask has to be maintained by hand
+static std::string BytesToPattern(const void* data, size_t length)
+{
+	std::string result;
+	result.reserve(length * 3);
+
+	for (size_t i = 0; i < length; ++i)
+	{
+		char byte[4];
+		snprintf(byte, sizeof(byte), "%02X ", static_cast<const uint8_t*>(data)[i]);
+		result.append(byte);
+	}
+	return result;
+}
+
+// Locates the operand of the single instruction referencing a GXT key. Both the key and the
+// reference must be unique, so binaries not holding to that are left alone instead of having
+// something unrelated patched
+static void* FindGxtKeyReference(const hook::scan_segments& rdata, const char* key)
+{
+	using namespace hook::txn;
+
+	// The terminator is included so a longer key sharing the prefix cannot match
+	const uintptr_t address = pattern(rdata, BytesToPattern(key, std::strlen(key) + 1)).get_one().get_uintptr();
+
+	return pattern(BytesToPattern(&address, sizeof(address))).get_one().get<void>();
+}
+
 void Patch_SA_NewBinaries_Common(HINSTANCE hInstance)
 {
 	using namespace Memory;
@@ -11298,21 +11326,22 @@ void Patch_SA_NewBinaries_Common(HINSTANCE hInstance)
 	TXN_CATCH();
 
 
-	// Swap the GANGS and CRIMES section names when exporting stats to stats.html
-	// Stat section 3 holds crime stats and section 4 holds gang stats, but the exporter
-	// labels them the other way around
+	// Swap the GANGS and CRIMES section names when exporting stats to stats.html.
+	// Stat section 3 holds crime stats and section 4 holds gang stats, but the exporter labels them the other way around.
+	// The switch printing those names is located through the GXT keys it references, since its shape differs between the compilers the game versions were built with
 	try
 	{
-		// GANGS, CRIMES, ACHIEVEMENTS, MISSIONS, MISC cases of the section name switch
-		auto section_names = pattern("6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? B9").get_one();
+		const hook::scan_segments rdata = hook::get_section_by_name(GetModuleHandle(nullptr), ".rdata");
 
-		const char* gangsHeader;
-		const char* crimesHeader;
-		Read(section_names.get<void>(3), gangsHeader);
-		Read(section_names.get<void>(9 + 3), crimesHeader);
+		void* gangsOperand = FindGxtKeyReference(rdata, "FES_GAN");
+		void* crimesOperand = FindGxtKeyReference(rdata, "FES_CRI");
 
-		Patch(section_names.get<void>(3), crimesHeader);
-		Patch(section_names.get<void>(9 + 3), gangsHeader);
+		uintptr_t gangsHeader, crimesHeader;
+		Read(gangsOperand, gangsHeader);
+		Read(crimesOperand, crimesHeader);
+
+		Patch(gangsOperand, crimesHeader);
+		Patch(crimesOperand, gangsHeader);
 	}
 	TXN_CATCH();
 }

--- a/SilentPatchSA/SilentPatchSA.cpp
+++ b/SilentPatchSA/SilentPatchSA.cpp
@@ -9303,34 +9303,6 @@ void Patch_SA_Steam()
 	InjectHook(0x5EDFD9, 0x5EE0FA, HookType::Jump);
 }
 
-// Formats raw bytes as an IDA style pattern, so no mask has to be maintained by hand
-static std::string BytesToPattern(const void* data, size_t length)
-{
-	std::string result;
-	result.reserve(length * 3);
-
-	for (size_t i = 0; i < length; ++i)
-	{
-		char byte[4];
-		snprintf(byte, sizeof(byte), "%02X ", static_cast<const uint8_t*>(data)[i]);
-		result.append(byte);
-	}
-	return result;
-}
-
-// Locates the operand of the single instruction referencing a GXT key. Both the key and the
-// reference must be unique, so binaries not holding to that are left alone instead of having
-// something unrelated patched
-static void* FindGxtKeyReference(const hook::scan_segments& rdata, const char* key)
-{
-	using namespace hook::txn;
-
-	// The terminator is included so a longer key sharing the prefix cannot match
-	const uintptr_t address = pattern(rdata, BytesToPattern(key, std::strlen(key) + 1)).get_one().get_uintptr();
-
-	return pattern(BytesToPattern(&address, sizeof(address))).get_one().get<void>();
-}
-
 void Patch_SA_NewBinaries_Common(HINSTANCE hInstance)
 {
 	using namespace Memory;
@@ -11327,22 +11299,20 @@ void Patch_SA_NewBinaries_Common(HINSTANCE hInstance)
 
 
 	// Swap the GANGS and CRIMES section names when exporting stats to stats.html. Stat section 3 holds crime
-	// stats and section 4 holds gang stats, but the exporter labels them the other way around.
-	// The switch printing those names is located through the GXT keys it references, since its shape differs
-	// between the compilers the game versions were built with
+	// stats and section 4 holds gang stats, but the exporter labels them the other way around
 	try
 	{
-		const hook::scan_segments rdata = hook::get_section_by_name(GetModuleHandle(nullptr), ".rdata");
+		// The GANGS, CRIMES, ACHIEVEMENTS, MISSIONS and MISC cases of the section name switch, each a fixed
+		// nine bytes of push 0 / push offset / jmp short, ending on the mov ecx that loads TheText
+		auto section_names = pattern("6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? B9").get_one();
 
-		void* gangsOperand = FindGxtKeyReference(rdata, "FES_GAN");
-		void* crimesOperand = FindGxtKeyReference(rdata, "FES_CRI");
+		const char* gangsHeader;
+		const char* crimesHeader;
+		Read(section_names.get<void>(3), gangsHeader);
+		Read(section_names.get<void>(9 + 3), crimesHeader);
 
-		uintptr_t gangsHeader, crimesHeader;
-		Read(gangsOperand, gangsHeader);
-		Read(crimesOperand, crimesHeader);
-
-		Patch(gangsOperand, crimesHeader);
-		Patch(crimesOperand, gangsHeader);
+		Patch(section_names.get<void>(3), crimesHeader);
+		Patch(section_names.get<void>(9 + 3), gangsHeader);
 	}
 	TXN_CATCH();
 }

--- a/SilentPatchSA/SilentPatchSA.cpp
+++ b/SilentPatchSA/SilentPatchSA.cpp
@@ -8450,6 +8450,19 @@ void Patch_SA_10(HINSTANCE hInstance)
 		Patch(0x461BB0 + 1, swat_model_id);
 		Patch(0x461BE6 + 1, army_model_id);
 	}
+
+	// Swap the GANGS and CRIMES section names when exporting stats to stats.html
+	// Stat section 3 holds crime stats and section 4 holds gang stats, but the exporter
+	// labels them the other way around
+	{
+		const char* gangsHeader;
+		const char* crimesHeader;
+		Read(0x57E023 + 1, gangsHeader);
+		Read(0x57E02C + 1, crimesHeader);
+
+		Patch(0x57E023 + 1, crimesHeader);
+		Patch(0x57E02C + 1, gangsHeader);
+	}
 }
 
 void Patch_SA_11()
@@ -11281,6 +11294,25 @@ void Patch_SA_NewBinaries_Common(HINSTANCE hInstance)
 
 		Patch(generate_road_blocks.get<void>(0xA), swat_model_id);
 		Patch(generate_road_blocks.get<void>(0x48), army_model_id);
+	}
+	TXN_CATCH();
+
+
+	// Swap the GANGS and CRIMES section names when exporting stats to stats.html
+	// Stat section 3 holds crime stats and section 4 holds gang stats, but the exporter
+	// labels them the other way around
+	try
+	{
+		// GANGS, CRIMES, ACHIEVEMENTS, MISSIONS, MISC cases of the section name switch
+		auto section_names = pattern("6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? EB ? 6A 00 68 ? ? ? ? B9").get_one();
+
+		const char* gangsHeader;
+		const char* crimesHeader;
+		Read(section_names.get<void>(3), gangsHeader);
+		Read(section_names.get<void>(9 + 3), crimesHeader);
+
+		Patch(section_names.get<void>(3), crimesHeader);
+		Patch(section_names.get<void>(9 + 3), gangsHeader);
 	}
 	TXN_CATCH();
 }


### PR DESCRIPTION
Fixes #447

### What's going on?
The `stats.html` exporter labels stat section 3 `FES_GAN` and section 4 `FES_CRI`,
but `CStats::ConstructStatLine` fills section 3 from the crime stat table and
section 4 from the gang stat table, so both headers end up over the wrong stats.
The GXT entries themselves are correct. See the issue for the full breakdown.

### How does it happen?
Both code paths read the two `push offset` operands of the section name switch and
write them back swapped. The section tables are deliberately left alone, they are
shared with the in-game Stats menu, whereas both GXT keys are referenced only by
this switch.

For 1.0 the addresses are hardcoded. For the new binaries the switch is located by
pattern - every case is a fixed 9-byte block (`push 0` / `push imm32` /
`jmp short`), so the two operands sit at `+3` and `+12` of the match:

```
6A 00 68 ? ? ? ? EB ? (x4)  6A 00 68 ? ? ? ? B9
```

The trailing `B9` (`mov ecx, TheText`) anchors the end of the chain.
This pattern has exactly one match in the 1.0 US `.text`.

### Final tests performed
- 1.0 US: verified in-game. `stats.html` now prints `CRIMES` above the crime stats
  and `GANGS` above the gang stats; the in-game Stats menu is unchanged.
- New binaries: not tested - I don't have those executables at hand. The pattern is
  derived from the 1.0 layout, and the code is inside `TXN_CATCH()`, so a miss is
  a no-op rather than a failure.