### PR TITLE
Add a premake build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,35 @@ for both first-time players and the old guard returning for yet another playthro
 ## Compilation requirements
 
 * Visual Studio 2017 or newer with `C++ Windows XP Support for VS 2017 (v141) tools` installed. Newer toolsets will work too, but the projects will require retargeting.
+* [premake5](https://premake.github.io/download), on `PATH`.
 * [vcpkg](https://vcpkg.io/) installed separately or as a Visual Studio component. Necessary for SP for San Andreas to include `libflac`.
 * RenderWare Graphics SDK. Each game requires their corresponding RenderWare version and an environment variable pointing at the `RW3.x\Graphics\rwsdk` directory:
   * GTA III: RW 3.3, D3D8, `RWG33SDK` variable.
   * GTA Vice City: RW 3.4, D3D8, `RWG34SDK` variable.
   * GTA San Andreas: RW 3.6, D3D9, `RWG36SDK` variable.
+
+  Set `RENDERWARE_ROOT` instead if all three live under one directory, or pass `/rwsdk` below to source the headers from
+  [plugin-sdk](https://github.com/DK22Pac/plugin-sdk).
+
+## Building
+
+```
+git submodule update --init --recursive
+createallprojects.bat
+```
+
+| Script | Projects |
+| --- | --- |
+| `createallprojects.bat` | all three games plus the ddraw proxy |
+| `creategameprojects.bat` | the three games |
+| `createddrawproject.bat` | just the ddraw proxy — needs no RenderWare SDK and no vcpkg |
+
+Each takes an optional premake action (`vs2022` by default) and the switches `/rwsdk` and `/open`, in any order. The
+v141_xp toolset is selected when it is installed, and the default toolset otherwise, with a warning that the result will
+not load on Windows XP.
+
+The solution is written to `build\SilentPatch.sln`; the `SilentPatch.sln` in the root is the MSBuild one and is left
+alone. `premake5` can also be run directly — `premake5 --projects=sa vs2022` generates San Andreas on its own.
 
 ## Contribution guidelines
 

--- a/SilentPatchSA/vcpkg.json
+++ b/SilentPatchSA/vcpkg.json
@@ -1,4 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
-    "dependencies": ["libflac"]
+    "dependencies": ["libflac"],
+    "builtin-baseline": "eaca4a577b6b678c6e10252754b6988a61746c19"
 }

--- a/createallprojects.bat
+++ b/createallprojects.bat
@@ -1,0 +1,12 @@
+@echo off
+rem Generates a solution with every project: all three games plus the ddraw proxy.
+rem
+rem   createallprojects.bat [action] [/rwsdk] [/open]
+rem
+rem Needs all three RenderWare SDKs. Pass /rwsdk to fetch headers from
+rem plugin-sdk instead, or use creategameprojects.bat / createddrawproject.bat
+rem if you only have some of them.
+
+set "SILENTPATCH_CALLER=%~nx0"
+call "%~dp0devtools\createprojects.bat" all %*
+exit /b %ERRORLEVEL%

--- a/createddrawproject.bat
+++ b/createddrawproject.bat
@@ -1,0 +1,11 @@
+@echo off
+rem Generates a solution with just the ddraw proxy.
+rem
+rem   createddrawproject.bat [action] [/rwsdk] [/open]
+rem
+rem This is the one project that needs no RenderWare SDK and no vcpkg, so it is
+rem the quickest way to check a toolchain is set up correctly.
+
+set "SILENTPATCH_CALLER=%~nx0"
+call "%~dp0devtools\createprojects.bat" ddraw %*
+exit /b %ERRORLEVEL%

--- a/creategameprojects.bat
+++ b/creategameprojects.bat
@@ -1,0 +1,11 @@
+@echo off
+rem Generates a solution with the three game projects, leaving out the ddraw proxy.
+rem
+rem   creategameprojects.bat [action] [/rwsdk] [/open]
+rem
+rem Pass /rwsdk to fetch RenderWare headers from plugin-sdk rather than
+rem supplying the original SDKs yourself.
+
+set "SILENTPATCH_CALLER=%~nx0"
+call "%~dp0devtools\createprojects.bat" games %*
+exit /b %ERRORLEVEL%

--- a/devtools/createprojects.bat
+++ b/devtools/createprojects.bat
@@ -1,0 +1,121 @@
+@echo off
+rem ---------------------------------------------------------------------------
+rem  createprojects.bat
+rem
+rem  Shared implementation behind the create*projects.bat scripts in the root.
+rem  Generates a Visual Studio solution with premake.
+rem
+rem  Usage: createprojects.bat <projects> [action] [/rwsdk] [/open]
+rem
+rem    action  premake action, e.g. vs2022 (default) or vs2019.
+rem    /rwsdk  provision RenderWare headers from plugin-sdk instead of using
+rem            the original SDKs. See devtools\fetch-renderware.bat.
+rem    /open   open the generated solution when done.
+rem
+rem  The generated solution lands in build\, NOT in the root - the
+rem  SilentPatch.sln checked into git is the MSBuild one and is left alone.
+rem ---------------------------------------------------------------------------
+
+setlocal
+
+rem Captured before the argument loop below: a bare "shift" moves %0 along with
+rem everything else, so %~dp0 stops pointing at this script once parsing starts.
+set "SCRIPTDIR=%~dp0"
+for %%I in ("%~dp0..") do set "ROOT=%%~fI"
+
+set "PROJECTS=%~1"
+if "%PROJECTS%"=="" set "PROJECTS=all"
+
+rem Everything after the project set is optional and order-independent:
+rem switches start with /, and the first bare word is the premake action.
+set "ACTION="
+set "OPEN="
+set "FETCHRW="
+
+rem shift /2 leaves %0 and the project set in %1 alone.
+:parse
+if "%~2"=="" goto :parsed
+if /i "%~2"=="/open"  ( set "OPEN=1"    & shift /2 & goto :parse )
+if /i "%~2"=="/rwsdk" ( set "FETCHRW=1" & shift /2 & goto :parse )
+if not defined ACTION ( set "ACTION=%~2" & shift /2 & goto :parse )
+echo ERROR: unrecognised argument "%~2"
+exit /b 1
+:parsed
+
+if "%ACTION%"=="" set "ACTION=%SILENTPATCH_ACTION%"
+if "%ACTION%"=="" set "ACTION=vs2022"
+
+rem The root wrappers announce themselves so error messages can name the script
+rem that was actually run rather than this one.
+set "CALLER=%SILENTPATCH_CALLER%"
+if "%CALLER%"=="" set "CALLER=%~nx0 %PROJECTS%"
+
+where premake5 >nul 2>&1
+if errorlevel 1 (
+	echo.
+	echo ERROR: premake5 was not found on PATH.
+	echo        Get it from https://premake.github.io/download and put it on PATH.
+	echo.
+	exit /b 1
+)
+
+rem Releases are built with the XP toolset, so use it when it is installed and
+rem fall back to the default toolset otherwise. Microsoft.VisualStudio.Component.WinXP
+rem is the component that carries both v141_xp and the Windows 7.0 SDK.
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+set "XPTOOLSET="
+set "TOOLSETARG="
+if exist "%VSWHERE%" (
+	for /f "usebackq tokens=*" %%I in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.WinXP -property installationPath 2^>nul`) do set "XPTOOLSET=%%I"
+)
+if not defined XPTOOLSET set "TOOLSETARG=--modern-toolset"
+
+rem Optional: provision RenderWare headers from plugin-sdk instead of requiring
+rem the original SDKs. Off unless /rwsdk is passed.
+if defined FETCHRW (
+	call "%SCRIPTDIR%fetch-renderware.bat"
+	if errorlevel 1 exit /b 1
+	set "RWG33SDK=%ROOT%\build\renderware\III"
+	set "RWG34SDK=%ROOT%\build\renderware\VC"
+	set "RWG36SDK=%ROOT%\build\renderware\SA"
+)
+
+echo.
+echo Generating SilentPatch projects
+echo     projects : %PROJECTS%
+echo     action   : %ACTION%
+if defined FETCHRW echo     rwsdk    : fetched from plugin-sdk
+if defined TOOLSETARG (
+	echo.
+	echo     NOTE: the v141_xp toolset is not installed, so the default toolset
+	echo           was selected. The modules will not load on Windows XP.
+	echo           Install "C++ Windows XP Support for VS 2017 [v141] tools"
+	echo           to build them the way releases are built.
+)
+echo.
+
+pushd "%ROOT%"
+premake5 --projects=%PROJECTS% %TOOLSETARG% %ACTION%
+set "RESULT=%ERRORLEVEL%"
+popd
+
+if not "%RESULT%"=="0" (
+	echo.
+	echo Project generation FAILED.
+	echo.
+	exit /b %RESULT%
+)
+
+set "SLN=%ROOT%\build\SilentPatch.sln"
+
+echo.
+echo Done. Solution written to:
+echo     %SLN%
+echo.
+
+if defined OPEN (
+	echo Opening solution...
+	start "" "%SLN%"
+)
+
+exit /b 0

--- a/devtools/fetch-renderware.bat
+++ b/devtools/fetch-renderware.bat
@@ -1,0 +1,114 @@
+@echo off
+rem ---------------------------------------------------------------------------
+rem  fetch-renderware.bat
+rem
+rem  Assembles a RenderWare header tree from plugin-sdk, so the games can be
+rem  built without the original RenderWare Graphics SDKs.
+rem
+rem  plugin-sdk carries RenderWare headers written for GTA modding, and they
+rem  cover everything SilentPatch touches. What comes out of here is only
+rem  headers - SilentPatch never links against RenderWare, it resolves the real
+rem  functions out of the game's own binary at runtime.
+rem
+rem  Run directly, or through the /rwsdk switch on the create*projects scripts.
+rem
+rem  Layout produced, matching what RWG33SDK / RWG34SDK / RWG36SDK expect:
+rem      build\renderware\III\include\d3d8\
+rem      build\renderware\VC\include\d3d8\
+rem      build\renderware\SA\include\d3d9\
+rem ---------------------------------------------------------------------------
+
+setlocal
+
+for %%I in ("%~dp0..") do set "ROOT=%%~fI"
+
+set "CLONE=%ROOT%\build\plugin-sdk"
+set "DEST=%ROOT%\build\renderware"
+set "REPO=https://github.com/DK22Pac/plugin-sdk.git"
+
+rem Already assembled? Nothing to do. Delete build\renderware to force a redo.
+if exist "%DEST%\SA\include\d3d9\rwcore.h" (
+	echo RenderWare headers already present in %DEST%
+	goto :export
+)
+
+where git >nul 2>&1
+if errorlevel 1 (
+	echo.
+	echo ERROR: git was not found on PATH, so plugin-sdk cannot be fetched.
+	echo.
+	exit /b 1
+)
+
+if not exist "%CLONE%\.git" (
+	echo Fetching plugin-sdk into %CLONE%
+	git clone --depth 1 --filter=blob:none --sparse "%REPO%" "%CLONE%"
+	if errorlevel 1 (
+		echo ERROR: failed to clone plugin-sdk.
+		exit /b 1
+	)
+	git -C "%CLONE%" sparse-checkout set plugin_III/game_III/rw plugin_vc/game_vc/rw plugin_sa/game_sa/rw
+	if errorlevel 1 (
+		echo ERROR: failed to narrow the plugin-sdk checkout.
+		exit /b 1
+	)
+)
+
+echo Assembling header tree in %DEST%
+
+call :stage III plugin_III\game_III d3d8 || exit /b 1
+call :stage VC  plugin_vc\game_vc   d3d8 || exit /b 1
+call :stage SA  plugin_sa\game_sa   d3d9 || exit /b 1
+
+rem -----------------------------------------------------------------------
+rem  Two fixups. plugin-sdk declares RwEngineInstance as a reference to a
+rem  pointer, which is its own idiom for game globals rather than RenderWare's,
+rem  and it leaves animKeyFrameSize commented out.
+rem
+rem  Both edits are verified rather than assumed - if plugin-sdk ever changes
+rem  those lines, this stops here instead of failing later as a confusing
+rem  compile error.
+rem -----------------------------------------------------------------------
+call :patch "%DEST%\III\include\d3d8\rwplcore.h" "\*&RwEngineInstance" "*RwEngineInstance" || exit /b 1
+call :patch "%DEST%\VC\include\d3d8\rwplcore.h"  "\*&RwEngineInstance" "*RwEngineInstance" || exit /b 1
+call :patch "%DEST%\SA\include\d3d9\rwplcore.h"  "\*&RwEngineInstance" "*RwEngineInstance" || exit /b 1
+call :patch "%DEST%\SA\include\d3d9\rtanim.h"    "//(\s*RwInt32\s+animKeyFrameSize;)" "$1" || exit /b 1
+
+:export
+echo.
+echo RenderWare headers ready:
+echo     RWG33SDK=%DEST%\III
+echo     RWG34SDK=%DEST%\VC
+echo     RWG36SDK=%DEST%\SA
+echo.
+exit /b 0
+
+
+rem ---------------------------------------------------------------------------
+rem  :stage <game dir> <plugin-sdk subdir> <api>
+rem ---------------------------------------------------------------------------
+:stage
+set "SRC=%CLONE%\%~2\rw"
+set "OUT=%DEST%\%~1\include\%~3"
+
+if not exist "%SRC%\rwcore.h" (
+	echo ERROR: %SRC%\rwcore.h is missing - the plugin-sdk layout has changed.
+	exit /b 1
+)
+
+if not exist "%OUT%\rw" mkdir "%OUT%\rw" >nul 2>&1
+copy /y "%SRC%\*" "%OUT%\" >nul
+rem Some headers reach for their error files as rw\<name>.rpe, so they go in twice.
+copy /y "%SRC%\*.rpe" "%OUT%\rw\" >nul 2>&1
+exit /b 0
+
+
+rem ---------------------------------------------------------------------------
+rem  :patch <file> <regex> <replacement>
+rem ---------------------------------------------------------------------------
+:patch
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+	"$f = '%~1'; $b = [IO.File]::ReadAllText($f); $a = $b -replace '%~2', '%~3';" ^
+	"if ($a -eq $b) { Write-Host ('ERROR: no-op patch on ' + (Split-Path $f -Leaf) + ' - plugin-sdk has changed'); exit 1 };" ^
+	"[IO.File]::WriteAllText($f, $a); Write-Host ('  patched ' + (Split-Path $f -Leaf))"
+exit /b %ERRORLEVEL%

--- a/premake/renderware.lua
+++ b/premake/renderware.lua
@@ -1,0 +1,87 @@
+-- Locates the RenderWare Graphics SDKs. Each game is built against the
+-- RenderWare version it originally shipped with, so there is one SDK per game
+-- rather than a single shared one.
+--
+-- These cannot be downloaded: RenderWare Graphics is proprietary Criterion/EA
+-- middleware that was never distributed publicly. All this does is find a copy
+-- that is already on the machine. Only headers are needed - SilentPatch never
+-- links against RenderWare, it resolves the real functions out of the game's
+-- own binary at runtime.
+--
+-- Set RWG33SDK / RWG34SDK / RWG36SDK to a game's rwsdk directory, or
+-- RENDERWARE_ROOT to a directory holding all three.
+
+local GAMES = {
+	III = { var = "RWG33SDK", api = "d3d8", version = "3.3", compact = "33" },
+	VC  = { var = "RWG34SDK", api = "d3d8", version = "3.4", compact = "34" },
+	SA  = { var = "RWG36SDK", api = "d3d9", version = "3.6", compact = "36" },
+}
+
+local function env(name)
+	local value = os.getenv(name)
+	if value == nil or value == "" then
+		return nil
+	end
+	return value
+end
+
+-- Layouts an SDK tends to get unpacked into, relative to a search root.
+local function candidates(game)
+	local root = env("RENDERWARE_ROOT")
+	if root == nil then
+		return {}
+	end
+
+	local list = {}
+	for _, layout in ipairs {
+		"/RW" .. game.version .. "/Graphics/rwsdk",
+		"/RW" .. game.compact .. "/Graphics/rwsdk",
+		"/" .. game.version .. "/Graphics/rwsdk",
+		"/RenderWare Graphics " .. game.version .. "/rwsdk",
+		"/Graphics/rwsdk",
+		"/rwsdk",
+		"",
+	} do
+		table.insert(list, root .. layout)
+	end
+	return list
+end
+
+-- Adds the include directory for a game's RenderWare SDK to the current project.
+function renderware_includedirs(name)
+	local game = GAMES[name]
+	if game == nil then
+		error("renderware: unknown game " .. tostring(name))
+	end
+
+	local sdk = env(game.var)
+
+	if sdk == nil then
+		for _, candidate in ipairs(candidates(game)) do
+			if os.isfile(candidate .. "/include/" .. game.api .. "/rwcore.h") then
+				sdk = candidate
+				break
+			end
+		end
+	end
+
+	if sdk == nil then
+		error(string.format(
+			"RenderWare Graphics %s SDK not found.\n" ..
+			"Point %s at its rwsdk directory, or RENDERWARE_ROOT at a directory holding all three.\n" ..
+			"Alternatively pass /rwsdk to the create*projects scripts to source the headers\n" ..
+			"from plugin-sdk, or --projects= to generate only what you have SDKs for.",
+			game.version, game.var))
+	end
+
+	local includedir = sdk .. "/include/" .. game.api
+
+	if not os.isfile(includedir .. "/rwcore.h") then
+		error(string.format(
+			"%s is set to \"%s\", but %s/rwcore.h does not exist.\n" ..
+			"It should point at the rwsdk directory of a RenderWare Graphics %s install.",
+			game.var, sdk, includedir, game.version))
+	end
+
+	includedirs { includedir }
+end

--- a/premake/vcpkg.lua
+++ b/premake/vcpkg.lua
@@ -1,0 +1,55 @@
+-- Adds the vcpkg properties Visual Studio understands to the generated
+-- projects. SilentPatchSA needs VcpkgEnableManifest and VcpkgUseStatic to pick
+-- up libflac from its vcpkg.json.
+
+require('vstudio')
+
+premake.api.register {
+	name = "vcpkg",
+	scope = "config",
+	kind = "boolean"
+}
+premake.api.register {
+	name = "vcpkgmanifest",
+	scope = "config",
+	kind = "boolean"
+}
+premake.api.register {
+	name = "vcpkgstatic",
+	scope = "config",
+	kind = "boolean"
+}
+premake.api.register {
+	name = "vcpkgconfig",
+	scope = "config",
+	kind = "string"
+}
+-- vcpkg looks for vcpkg.json in directories above the project file. Generated
+-- projects do not sit next to the manifest, so the root is given explicitly.
+premake.api.register {
+	name = "vcpkgmanifestroot",
+	scope = "config",
+	kind = "string"
+}
+
+premake.override(premake.vstudio.vc2010.elements, "configurationProperties", function(base, cfg)
+	local calls = base(cfg)
+	table.insert(calls, function(cfg)
+		if cfg.vcpkg ~= nil then
+			premake.w('<VcpkgEnabled>%s</VcpkgEnabled>', cfg.vcpkg)
+		end
+		if cfg.vcpkgmanifest ~= nil then
+			premake.w('<VcpkgEnableManifest>%s</VcpkgEnableManifest>', cfg.vcpkgmanifest)
+		end
+		if cfg.vcpkgstatic ~= nil then
+			premake.w('<VcpkgUseStatic>%s</VcpkgUseStatic>', cfg.vcpkgstatic)
+		end
+		if cfg.vcpkgconfig ~= nil then
+			premake.w('<VcpkgConfiguration>%s</VcpkgConfiguration>', cfg.vcpkgconfig)
+		end
+		if cfg.vcpkgmanifestroot ~= nil then
+			premake.w('<VcpkgManifestRoot>%s</VcpkgManifestRoot>', cfg.vcpkgmanifestroot)
+		end
+	end)
+	return calls
+end)

--- a/premake/versionmeta.lua
+++ b/premake/versionmeta.lua
@@ -1,0 +1,54 @@
+-- Each project carries its module name, revision and copyright range in a
+-- versionmeta.props sheet, which SilentPatch.rc turns into the VS_VERSION_INFO
+-- block. Those sheets are read here rather than duplicated, so a revision bump
+-- is still made in one place and both build systems pick it up.
+
+local KEYS = {
+	"SILENTPATCH_NAME",
+	"SILENTPATCH_EXT",
+	"SILENTPATCH_FULL_NAME",
+	"SILENTPATCH_REVISION_ID",
+	"SILENTPATCH_BUILD_ID",
+	"SILENTPATCH_COPYRIGHT",
+}
+
+local function trim(s)
+	return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+-- Reads <dir>/versionmeta.props and returns the values as a table.
+function read_version_meta(dir)
+	local path = dir .. "/versionmeta.props"
+
+	local file = io.open(path, "r")
+	if not file then
+		error("versionmeta: cannot open " .. path)
+	end
+	local xml = file:read("*a")
+	file:close()
+
+	local meta = {}
+	for _, key in ipairs(KEYS) do
+		local value = xml:match("<" .. key .. ">(.-)</" .. key .. ">")
+		if not value then
+			error("versionmeta: " .. path .. " does not define " .. key)
+		end
+		meta[key] = trim(value)
+	end
+	return meta
+end
+
+-- Applies a project's version metadata as preprocessor definitions, and hands
+-- back the table so the caller can reuse the name and extension. The values are
+-- deliberately unquoted: SilentPatch.rc stringizes them itself.
+function version_info(dir)
+	local meta = read_version_meta(dir)
+
+	local list = {}
+	for _, key in ipairs(KEYS) do
+		table.insert(list, key .. "=" .. meta[key])
+	end
+	defines(list)
+
+	return meta
+end

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,0 +1,250 @@
+dofile "premake/vcpkg.lua"
+dofile "premake/versionmeta.lua"
+dofile "premake/renderware.lua"
+
+newoption {
+	trigger = "modern-toolset",
+	description = "Build with the default toolset instead of v141_xp. The modules will not load on Windows XP."
+}
+
+newoption {
+	trigger = "projects",
+	value = "SET",
+	description = "Which projects to generate (default: all)",
+	allowed = {
+		{ "all",   "Every project" },
+		{ "games", "The three games, without the ddraw proxy" },
+		{ "iii",   "GTA III only" },
+		{ "vc",    "Vice City only" },
+		{ "sa",    "San Andreas only" },
+		{ "ddraw", "The ddraw proxy only" },
+	}
+}
+
+-- Each game needs its own RenderWare SDK, and contributors rarely have all
+-- three, so generating a subset has to be possible.
+local SELECTION = _OPTIONS["projects"] or "all"
+
+local function wanted(name)
+	if SELECTION == "all" then return true end
+	if SELECTION == "games" then return name ~= "ddraw" end
+	return SELECTION == name
+end
+
+local function toolset_for_configuration()
+	if _OPTIONS["modern-toolset"] then
+		return nil
+	end
+	return "msc-v141_xp"
+end
+
+-- Files shared between projects. Each game pulls in a different subset, and
+-- with different defines, so //SilentPatch is compiled into every module
+-- rather than built once as a library.
+local SHARED = {
+	base = {
+		"SilentPatch/Desktop.cpp", "SilentPatch/Desktop.h",
+		"SilentPatch/Utils/Patterns.cpp", "SilentPatch/Utils/Patterns.h",
+		"SilentPatch/Utils/MemoryMgr.h",
+	},
+	ddraw = {
+		"SilentPatch/Common_ddraw.cpp", "SilentPatch/Common_ddraw.h",
+	},
+	game = {
+		"SilentPatch/ParseUtils.cpp", "SilentPatch/ParseUtils.hpp",
+		"SilentPatch/SVF.cpp", "SilentPatch/SVF.h",
+		"SilentPatch/TheFLAUtils.cpp", "SilentPatch/TheFLAUtils.h",
+		"SilentPatch/Maths.h", "SilentPatch/MemoryMgr.GTA.h",
+		"SilentPatch/Random.h", "SilentPatch/RWUtils.hpp",
+		"SilentPatch/debugmenu_public.h",
+	},
+	iii_vc = {
+		"SilentPatch/Common.cpp", "SilentPatch/Common.h",
+		"SilentPatch/RWGTA.cpp", "SilentPatch/RWGTA.h",
+		"SilentPatch/StoredCar.cpp", "SilentPatch/StoredCar.h",
+		"SilentPatch/Timer.cpp", "SilentPatch/Timer.h",
+		"SilentPatch/ExternalBindings.hpp", "SilentPatch/StdAfx.h",
+	},
+	sa = {
+		"SilentPatch/FriendlyMonitorNames.cpp", "SilentPatch/FriendlyMonitorNames.h",
+	},
+	resources = {
+		"SilentPatch/SilentPatch.rc", "SilentPatch/resource1.h",
+		"SilentPatch/ExternalBindings.natvis",
+	},
+}
+
+-- Translation units that must not use the precompiled header, matching the
+-- PrecompiledHeader=NotUsing entries in the .vcxproj files.
+local NO_PCH = {
+	"SilentPatch/Common.cpp",
+	"SilentPatch/Common_ddraw.cpp",
+	"SilentPatch/Desktop.cpp",
+	"SilentPatch/FriendlyMonitorNames.cpp",
+	"SilentPatch/ParseUtils.cpp",
+	"SilentPatch/RWGTA.cpp",
+	"SilentPatch/SVF.cpp",
+	"SilentPatch/TheFLAUtils.cpp",
+	"SilentPatch/Utils/Patterns.cpp",
+}
+
+local function no_pch()
+	for _, file in ipairs(NO_PCH) do
+		filter { "files:" .. file }
+			enablepch "off"
+	end
+	filter {}
+end
+
+local function module(name, dir)
+	local meta = version_info(dir)
+
+	kind "SharedLib"
+	language "C++"
+	targetname(meta.SILENTPATCH_NAME)
+	targetextension(meta.SILENTPATCH_EXT)
+	includedirs { "SilentPatch", dir }
+end
+
+
+workspace "SilentPatch"
+	platforms { "Win32" }
+
+if wanted("iii") then
+project "SilentPatchIII"
+	module("SilentPatchIII", "SilentPatchIII")
+	defines { "_GTA_III" }
+	renderware_includedirs "III"
+
+	files(SHARED.base)
+	files(SHARED.ddraw)
+	files(SHARED.game)
+	files(SHARED.iii_vc)
+	files(SHARED.resources)
+	files { "SilentPatchIII/*.cpp", "SilentPatchIII/*.h" }
+
+	pchheader "StdAfx.h"
+	pchsource "SilentPatchIII/StdAfxIII.cpp"
+	no_pch()
+
+end
+
+if wanted("vc") then
+project "SilentPatchVC"
+	module("SilentPatchVC", "SilentPatchVC")
+	defines { "_GTA_VC" }
+	renderware_includedirs "VC"
+
+	files(SHARED.base)
+	files(SHARED.ddraw)
+	files(SHARED.game)
+	files(SHARED.iii_vc)
+	files(SHARED.resources)
+	files { "SilentPatchVC/*.cpp", "SilentPatchVC/*.h" }
+
+	pchheader "StdAfx.h"
+	pchsource "SilentPatchVC/StdAfxVC.cpp"
+	no_pch()
+
+end
+
+if wanted("sa") then
+project "SilentPatchSA"
+	module("SilentPatchSA", "SilentPatchSA")
+	defines { "_GTA_SA" }
+	renderware_includedirs "SA"
+
+	files(SHARED.base)
+	files(SHARED.game)
+	files(SHARED.sa)
+	files(SHARED.resources)
+	files { "SilentPatchSA/*.cpp", "SilentPatchSA/*.h", "SilentPatchSA/SilentPatchSA.rc" }
+
+	pchheader "StdAfxSA.h"
+	pchsource "SilentPatchSA/StdAfxSA.cpp"
+	no_pch()
+
+	-- libflac, restored from SilentPatchSA/vcpkg.json. The generated project
+	-- does not sit next to that manifest, so vcpkg is told where it is.
+	vcpkg "On"
+	vcpkgmanifest "On"
+	vcpkgstatic "On"
+	vcpkgmanifestroot "$(MSBuildProjectDirectory)\\..\\SilentPatchSA"
+
+	filter "configurations:Shipping"
+		defines { "_SECURE_SCL=0" }
+	filter {}
+
+end
+
+if wanted("ddraw") then
+project "DDraw"
+	module("DDraw", "DDraw")
+
+	-- The version resource calls this SilentPatchDDraw, but the file on disk
+	-- has to be named ddraw.dll for the games to load it at all.
+	targetname "ddraw"
+
+	files(SHARED.base)
+	files(SHARED.ddraw)
+	files(SHARED.resources)
+	files { "DDraw/dllmain.cpp" }
+
+	-- A ddraw.dll proxy the games load on startup, which gets SilentPatch in
+	-- early enough to fix things that happen before an ASI loader would run.
+	linkoptions { "/DEF:\"%{wks.location}/../DDraw/DDraw.def\"" }
+
+
+end
+
+workspace "*"
+	configurations { "Debug", "Release", "Shipping" }
+	location "build"
+
+	vpaths {
+		["Headers/*"] = { "**.h", "**.hpp" },
+		["Sources/*"] = { "**.c", "**.cpp" },
+		["Resources"] = { "**.rc", "**.def", "**.natvis" },
+	}
+
+	toolset(toolset_for_configuration())
+
+	cppdialect "C++17"
+	characterset "Unicode"
+	staticruntime "on"
+	rtti "off"
+	symbols "on"
+	warnings "Extra"
+	conformancemode "on"
+	vectorextensions "IA32"
+
+	buildoptions { "/sdl", "/Zc:strictStrings", "/Zc:threadSafeInit-" }
+
+	defines { "_HAS_EXCEPTIONS=0", "PATTERNS_USE_HINTS=1" }
+
+	-- Loaded very early in the host process, so these are taken lazily.
+	linkoptions { "/LARGEADDRESSAWARE", "/DELAYLOAD:shell32.dll", "/DELAYLOAD:shlwapi.dll" }
+	links { "delayimp" }
+
+filter "configurations:Debug"
+	runtime "Debug"
+
+-- NDEBUG is deliberately absent from Release. SilentPatch.rc keys the major
+-- version off it, so Release builds identify as 0.1.<revision> and Shipping as
+-- 1.1.<revision> - which is how a build from a working tree is told apart from
+-- a published one.
+filter "configurations:Shipping"
+	defines { "NDEBUG" }
+	linkoptions { "/pdbaltpath:%_PDB%" }
+
+filter "configurations:not Debug"
+	optimize "Speed"
+	functionlevellinking "on"
+	linktimeoptimization "on"
+	inlining "auto"			-- InlineFunctionExpansion=AnySuitable
+	omitframepointer "on"
+	buildoptions { "/Ot" }		-- FavorSizeOrSpeed=Speed
+
+filter { "platforms:Win32" }
+	system "Windows"
+	architecture "x86"


### PR DESCRIPTION
Adds a premake build system alongside `SilentPatch.sln`, following the layout the newer SilentPatches use.

Reworked from the original CMake version after the review — thanks for the steer on both counts.

**The four compiler fixes are gone.** They were artifacts of building with v143/v145 rather than v141_xp, not latent bugs: the project builds fine on its supported toolset. In particular the `static inline` change was wrong, since omitting it is deliberate — worth a comment in the source at some point, as it reads like an oversight otherwise.

What remains is the build system plus one two-line commit adding include guards to the PCH roots, which is separable and defensive rather than required.

**12 files, +743, no deletions.**

---

## Layout

```
premake5.lua              workspace, the four projects, shared settings
premake/vcpkg.lua         vcpkg properties for the generated projects
premake/versionmeta.lua   reads the existing versionmeta.props sheets
premake/renderware.lua    RenderWare SDK discovery
```

The `vcpkg.lua` custom API block is lifted from SilentPatchNFS90s, with one addition described below. Configuration filters, `warnings "Extra"`, `staticruntime`, `cppdialect`, `location "build"` and the `Debug`/`Release`/`Shipping` split all follow the same shape as the existing premake scripts.

## Points worth flagging

**`NDEBUG` stays absent from Release.** `SilentPatch.rc` keys the major version off it, so Release builds identify as `0.1.<revision>` and Shipping as `1.1.<revision>`. This mirrors what the solution already does.

**Version metadata is read, not duplicated.** `premake/versionmeta.lua` parses the existing `versionmeta.props` files, so bumping a revision is still done in one place and both build systems pick it up. This deviates from the `VersionInfo.lua` convention in the newer repos — that made sense there, where premake is the only build system, but here it would mean two places to edit. Happy to switch to `VersionInfo.lua` files if you would rather have consistency.

**`VcpkgManifestRoot`.** premake puts generated projects in `build/`, and vcpkg only searches directories *above* the project file for `vcpkg.json`. Since `SilentPatchSA/vcpkg.json` is no longer an ancestor, the manifest root is emitted explicitly. That needed one extra property in the custom API block beyond the four in SilentPatchNFS90s.

**`--projects=`** generates a subset (`all`, `games`, `iii`, `vc`, `sa`, `ddraw`). Each game needs its own RenderWare SDK and contributors rarely have all three; `ddraw` needs neither an SDK nor vcpkg, so it doubles as a quick toolchain check.

**RenderWare SDKs are searched for** rather than demanded from three environment variables. Those still work and still take precedence; `RENDERWARE_ROOT` covers keeping all three under one directory. When nothing is found the error says what to set rather than producing a broken include path.

## Generator scripts

```
createallprojects.bat  [action] [/rwsdk] [/open]
creategameprojects.bat [action] [/rwsdk] [/open]
createddrawproject.bat [action] [/rwsdk] [/open]
```

They wrap premake and select the `v141_xp` toolset when it is installed, falling back to the default toolset with an explicit warning that the result will not load on Windows XP. `premake5` can equally be run directly.

`/rwsdk` runs `devtools\fetch-renderware.bat`, which sparse-clones [plugin-sdk](https://github.com/DK22Pac/plugin-sdk) and assembles a RenderWare header tree under `build\renderware`. Its headers cover everything SilentPatch uses, and headers are all that is needed, since SilentPatch resolves the real functions out of the game's own binary at runtime rather than linking against RenderWare. The two header fixups it applies (`RwEngineInstance`, `rtanim.h`) verify that the content actually changed, so a plugin-sdk reformat fails there rather than surfacing later as a confusing compile error.

Generated projects go to `build/`, so the checked-in `SilentPatch.sln` is never overwritten.

## Verification

Source and resource lists in the generated projects are identical to the existing `.vcxproj` files for all four targets — 14 / 14 / 22 / 4 sources. The mapped properties match too: `WarningLevel`, `LanguageStandard`, `ConformanceMode`, `EnableEnhancedInstructionSet`, `RuntimeTypeInfo`, `RuntimeLibrary`, `CharacterSet`, `PlatformToolset`, `TargetName`/`TargetExt`, `SubSystem`, the precompiled header `Create`/`Use`/`NotUsing` split, `Optimization`, `InlineFunctionExpansion`, `FavorSizeOrSpeed`, `OmitFramePointers`, `StringPooling`, `IntrinsicFunctions`, `FunctionLevelLinking`, `WholeProgramOptimization`/LTCG, `/LARGEADDRESSAWARE`, the delay-loaded imports, and `/pdbaltpath:%_PDB%` in Shipping.

DDraw builds and produces `ddraw.dll` at `1.1.7.0` with the version resource intact.

## Not verified

- **Not built with v141_xp** — that toolset was not available here, so only generation and property parity could be checked against it. On v143/v145 the three games hit the toolset issues described above, as expected.
- **Not run in-game.**
- **San Andreas was not built end to end.** vcpkg refuses the manifest with `this vcpkg instance requires a manifest with a specified baseline`, because the Visual Studio-bundled vcpkg is not a git checkout and `SilentPatchSA/vcpkg.json` carries no `builtin-baseline`. This is pre-existing and unrelated to the build system — the existing `SilentPatchSA.vcxproj` fails identically with the same vcpkg. Mentioning it only because it may be worth a `builtin-baseline` at some point.

## Notes

The two commits are separable. The second only adds `#pragma once` to the two PCH roots; premake uses `/Yu` like the solution does, so it is defensive rather than required, and can be dropped without affecting anything.
